### PR TITLE
Remove react-markdown from bundle

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -15,7 +15,7 @@ import postcss from 'rollup-plugin-postcss';
 
 export default {
   input: 'src/index.js', // Main JavaScript file
-  external: ['preact'], // Don’t bundle Preact
+  external: ['preact', 'react-markdown'], // Don’t bundle Preact
   plugins: [
     alias({
       entries: [


### PR DESCRIPTION
In the previous PR https://github.com/al-mabsut/muslimah/pull/42 we forgot to remove `react-markdown` from the bundle as it take a lot of space ( unpack size before: 4MB, after: 138.4KB )