### PR TITLE
combine all dependabot prs 2024 01 26 2966

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@al-mabsut/muslimah",
-  "version": "0.0.5",
+  "version": "0.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@al-mabsut/muslimah",
-      "version": "0.0.5",
+      "version": "0.0.8",
       "license": "ISC",
       "devDependencies": {
         "@babel/core": "^7.23.7",
@@ -10604,9 +10604,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.3.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
-      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.1.tgz",
+      "integrity": "sha512-CjA3y+Dr3FyFDOAMnxZEGtnW9KBR2M0JvvUtXNW+dYJL5ROWxP9DUHCwgFqpMk0OXCc0ljhaNTr2w/kutYIcHQ==",
       "dev": true,
       "engines": {
         "node": ">=12"


### PR DESCRIPTION
- Dependabot: Bump @storybook/preact from 7.6.7 to 7.6.10
- Dependabot: Bump @storybook/addon-interactions from 7.6.7 to 7.6.10
- Dependabot: Bump @storybook/addon-essentials from 7.6.7 to 7.6.10
- Dependabot: Bump @babel/helpers from 7.23.7 to 7.23.8
- Dependabot: Bump @humanwhocodes/object-schema from 2.0.1 to 2.0.2
- Dependabot: Bump pathe from 1.1.1 to 1.1.2
- Dependabot: Bump @babel/preset-env from 7.23.7 to 7.23.8
- Dependabot: Bump @babel/plugin-transform-classes from 7.23.5 to 7.23.8
- Dependabot: Bump @humanwhocodes/config-array from 0.11.13 to 0.11.14
- Dependabot: Bump acorn-walk from 8.3.1 to 8.3.2
- Dependabot: Bump @types/react from 18.2.47 to 18.2.48
- Dependabot: Bump @types/node-fetch from 2.6.10 to 2.6.11
- Dependabot: Bump set-function-length from 1.1.1 to 1.2.0
- Dependabot: Bump flow-parser from 0.225.1 to 0.227.0
- Dependabot: Bump @jridgewell/trace-mapping from 0.3.20 to 0.3.22
- Dependabot: Bump chai from 4.3.10 to 4.4.1
- Dependabot: Bump rollup from 4.9.2 to 4.9.6
- Dependabot: Bump babel-plugin-polyfill-regenerator from 0.5.4 to 0.5.5
- Dependabot: Bump storybook from 7.6.7 to 7.6.10
- Dependabot: Bump safe-regex-test from 1.0.0 to 1.0.2
- Dependabot: Bump @floating-ui/react-dom from 2.0.5 to 2.0.6
- Dependabot: Bump babel-plugin-polyfill-corejs2 from 0.4.7 to 0.4.8
- Dependabot: Bump safe-array-concat from 1.0.1 to 1.1.0
- Dependabot: Bump postcss-modules-local-by-default from 4.0.3 to 4.0.4
- Dependabot: Bump spdx-exceptions from 2.3.0 to 2.4.0
- Dependabot: Bump @testing-library/jest-dom from 6.2.0 to 6.3.0
- Dependabot: Bump electron-to-chromium from 1.4.623 to 1.4.645
- Dependabot: Bump caniuse-lite from 1.0.30001575 to 1.0.30001580
- Dependabot: Bump @adobe/css-tools from 4.3.2 to 4.3.3
- Dependabot: Bump dotenv from 16.3.1 to 16.4.1
