### PR TITLE
combine all dependabot prs 2024 01 28 8440

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2659,22 +2659,22 @@
       "dev": true
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.5.3.tgz",
-      "integrity": "sha512-O0WKDOo0yhJuugCx6trZQj5jVJ9yR0ystG2JaNAemYUWce+pmM6WUEFIibnWyEJKdrDxhm75NoSRME35FNaM/Q==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz",
+      "integrity": "sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==",
       "dev": true,
       "dependencies": {
-        "@floating-ui/utils": "^0.2.0"
+        "@floating-ui/utils": "^0.2.1"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.4.tgz",
-      "integrity": "sha512-jByEsHIY+eEdCjnTVu+E3ephzTOzkQ8hgUfGwos+bg7NlH33Zc5uO+QHz1mrQUOgIKKDD1RtS201P9NvAfq3XQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.0.tgz",
+      "integrity": "sha512-SZ0BEXzsaaS6THZfZJUcAobbZTD+MvfGM42bxgeg0Tnkp4/an/avqwAXiVLsFtIBZtfsx3Ymvwx0+KnnhdA/9g==",
       "dev": true,
       "dependencies": {
-        "@floating-ui/core": "^1.5.3",
-        "@floating-ui/utils": "^0.2.0"
+        "@floating-ui/core": "^1.6.0",
+        "@floating-ui/utils": "^0.2.1"
       }
     },
     "node_modules/@floating-ui/react-dom": {
@@ -7488,54 +7488,6 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@storybook/types": {
-      "version": "7.6.10",
-      "resolved": "https://registry.npmjs.org/@storybook/types/-/types-7.6.10.tgz",
-      "integrity": "sha512-hcS2HloJblaMpCAj2axgGV+53kgSRYPT0a1PG1IHsZaYQILfHSMmBqM8XzXXYTsgf9250kz3dqFX1l0n3EqMlQ==",
-      "dev": true,
-      "dependencies": {
-        "@storybook/channels": "7.6.10",
-        "@types/babel__core": "^7.0.0",
-        "@types/express": "^4.7.0",
-        "file-system-cache": "2.3.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      }
-    },
-    "node_modules/@storybook/types": {
-      "version": "7.6.10",
-      "resolved": "https://registry.npmjs.org/@storybook/types/-/types-7.6.10.tgz",
-      "integrity": "sha512-hcS2HloJblaMpCAj2axgGV+53kgSRYPT0a1PG1IHsZaYQILfHSMmBqM8XzXXYTsgf9250kz3dqFX1l0n3EqMlQ==",
-      "dev": true,
-      "dependencies": {
-        "@storybook/channels": "7.6.10",
-        "@types/babel__core": "^7.0.0",
-        "@types/express": "^4.7.0",
-        "file-system-cache": "2.3.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      }
-    },
-    "node_modules/@storybook/types": {
-      "version": "7.6.10",
-      "resolved": "https://registry.npmjs.org/@storybook/types/-/types-7.6.10.tgz",
-      "integrity": "sha512-hcS2HloJblaMpCAj2axgGV+53kgSRYPT0a1PG1IHsZaYQILfHSMmBqM8XzXXYTsgf9250kz3dqFX1l0n3EqMlQ==",
-      "dev": true,
-      "dependencies": {
-        "@storybook/channels": "7.6.10",
-        "@types/babel__core": "^7.0.0",
-        "@types/express": "^4.7.0",
-        "file-system-cache": "2.3.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
       }
     },
     "node_modules/@storybook/types": {


### PR DESCRIPTION
- Dependabot: Bump core-js from 3.35.0 to 3.35.1
- Dependabot: Bump @sinonjs/commons from 3.0.0 to 3.0.1
- Dependabot: Bump nypm from 0.3.4 to 0.3.6
- Dependabot: Bump core-js-compat from 3.35.0 to 3.35.1
- Dependabot: Bump vite from 5.0.11 to 5.0.12
- Dependabot: Bump @babel/helper-create-class-features-plugin
- Dependabot: Bump @babel/parser from 7.23.6 to 7.23.9
- Dependabot: Bump @babel/traverse from 7.23.7 to 7.23.9
- Dependabot: Bump electron-to-chromium from 1.4.645 to 1.4.647
- Dependabot: Bump @babel/plugin-transform-modules-systemjs
- Dependabot: Bump @types/express-serve-static-core
- Dependabot: Bump @babel/preset-env from 7.23.8 to 7.23.9
- Dependabot: Bump @floating-ui/core from 1.5.3 to 1.6.0
- Dependabot: Bump @babel/plugin-transform-async-generator-functions
- Dependabot: Bump @babel/types from 7.23.6 to 7.23.9
- Dependabot: Bump @babel/helpers from 7.23.8 to 7.23.9
- Dependabot: Bump @babel/runtime from 7.23.7 to 7.23.9
- Dependabot: Bump @babel/eslint-parser from 7.23.3 to 7.23.9
- Dependabot: Bump @babel/core from 7.23.7 to 7.23.9
- Dependabot: Bump @types/node from 18.19.5 to 18.19.10
- Dependabot: Bump @babel/template from 7.22.15 to 7.23.9
- Dependabot: Bump @floating-ui/react-dom from 2.0.6 to 2.0.7
- Dependabot: Bump @types/uuid from 9.0.7 to 9.0.8
- Dependabot: Bump @floating-ui/dom from 1.5.4 to 1.6.0
