### PR TITLE
combine all dependabot prs 2024 01 29 1351

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11991,9 +11991,9 @@
       "dev": true
     },
     "node_modules/fastq": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.16.0.tgz",
-      "integrity": "sha512-ifCoaXsDrsdkWTtiNJX5uzHDsrck5TzfKKDcuFFTIrrc/BS076qgEIfoIy1VeZqViznfKiysPYTh/QeHtnIsYA==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.0.tgz",
+      "integrity": "sha512-zGygtijUMT7jnk3h26kUms3BkSDp4IfIKjmnqI2tvx6nuBfiF1UqOxbnLfzdv+apBy+53oaImsKtMw/xYbW+1w==",
       "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"


### PR DESCRIPTION
- Dependabot: Bump caniuse-lite from 1.0.30001580 to 1.0.30001581
- Dependabot: Bump browserslist from 4.22.2 to 4.22.3
- Dependabot: Bump @floating-ui/react-dom from 2.0.7 to 2.0.8
- Dependabot: Bump @floating-ui/dom from 1.6.0 to 1.6.1
- Dependabot: Bump marked from 11.1.1 to 11.2.0
- Dependabot: Bump fastq from 1.16.0 to 1.17.0
