### PR TITLE
combine all dependabot prs 2024 01 30 3887

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7578,9 +7578,9 @@
       }
     },
     "node_modules/@testing-library/jest-dom": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.3.0.tgz",
-      "integrity": "sha512-hJVIrkFizEQxoWsGBlycTcQhrpoCH4DhXfrnHFFXgkx3Xdm15zycsq5Ep+vpw4W8S0NJa8cxDHcuJib+1tEbhg==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.4.0.tgz",
+      "integrity": "sha512-GgGT3OR8qhIjk2SBMy51AYDWoMnAyR/cwjZO4SttuBmIQ9wWy9QmVOeaSbgT5Bm0J6qLBaf4+dsJWfisvafoaA==",
       "dev": true,
       "dependencies": {
         "@adobe/css-tools": "^4.3.2",


### PR DESCRIPTION
- Dependabot: Bump electron-to-chromium from 1.4.648 to 1.4.650
- Dependabot: Bump markdown-to-jsx from 7.4.0 to 7.4.1
- Dependabot: Bump @testing-library/jest-dom from 6.3.0 to 6.4.0
