### PR TITLE
combine all dependabot prs 2024 02 10 5202

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21907,9 +21907,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.1.0.tgz",
-      "integrity": "sha512-STmSFzhY4ljuhz14bg9LkMTk3d98IO6DIArnTY6MeBwiD1Za2StcQtz7fzOUnRCqrHSD5+OS2reg4HOz1eoLnw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.1.1.tgz",
+      "integrity": "sha512-wclpAgY3F1tR7t9LL5CcHC41YPkQIpKUGeIuT8MdNwNZr6OqOTLs7JX5vIHAtzqLWXts0T+GDrh9pN2arneKqg==",
       "dev": true,
       "peer": true,
       "dependencies": {


### PR DESCRIPTION
- Dependabot: Bump tinyspy from 2.2.0 to 2.2.1
- Dependabot: Bump preact-render-to-string from 5.2.6 to 6.3.1
- Dependabot: Bump electron-to-chromium from 1.4.661 to 1.4.664
- Dependabot: Bump @types/node from 18.19.14 to 18.19.15
- Dependabot: Bump node-fetch-native from 1.6.1 to 1.6.2
- Dependabot: Bump vite from 5.1.0 to 5.1.1
