### PR TITLE
combine all dependabot prs 2024 02 14 1224

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11747,6 +11747,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
+      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.2.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-errors": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
@@ -13587,12 +13599,12 @@
       }
     },
     "node_modules/has-property-descriptors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
-      "integrity": "sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "dev": true,
       "dependencies": {
-        "get-intrinsic": "^1.2.2"
+        "es-define-property": "^1.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"


### PR DESCRIPTION
- Dependabot: Bump define-data-property from 1.1.2 to 1.1.3
- Dependabot: Bump @storybook/test from 7.6.13 to 7.6.14
- Dependabot: Bump electron-to-chromium from 1.4.664 to 1.4.667
- Dependabot: Bump dotenv from 16.4.1 to 16.4.3
- Dependabot: Bump call-bind from 1.0.6 to 1.0.7
- Dependabot: Bump @storybook/addon-interactions from 7.6.13 to 7.6.14
- Dependabot: Bump @storybook/preact-vite from 7.6.13 to 7.6.14
- Dependabot: Bump has-property-descriptors from 1.0.1 to 1.0.2
