### PR TITLE
combine all dependabot prs 2024 02 15 1350

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3645,9 +3645,9 @@
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
-      "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
       "dev": true,
       "engines": {
         "node": ">=6.0.0"


### PR DESCRIPTION
- Dependabot: Bump vite from 5.1.1 to 5.1.2
- Dependabot: Bump electron-to-chromium from 1.4.668 to 1.4.670
- Dependabot: Bump spdx-exceptions from 2.4.0 to 2.5.0
- Dependabot: Bump @types/node from 18.19.15 to 18.19.16
- Dependabot: Bump browserslist from 4.22.3 to 4.23.0
- Dependabot: Bump rollup from 4.10.0 to 4.11.0
- Dependabot: Bump flow-parser from 0.228.0 to 0.229.0
- Dependabot: Bump @jridgewell/resolve-uri from 3.1.1 to 3.1.2
