### PR TITLE
combine all dependabot prs 2024 02 21 2859

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5843,76 +5843,16 @@
       }
     },
     "node_modules/@storybook/addon-interactions": {
-      "version": "7.6.16",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-interactions/-/addon-interactions-7.6.16.tgz",
-      "integrity": "sha512-nOjbQCqX+u3yAwlaGHQZCoSkdsvctfiWxcUjMwDBdky2vPKUGLpfJs65w31ay/UgeR+ZWYROGwVMkOHzB4GOIA==",
+      "version": "7.6.17",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-interactions/-/addon-interactions-7.6.17.tgz",
+      "integrity": "sha512-6zlX+RDQ1PlA6fp7C+hun8t7h2RXfCGs5dGrhEenp2lqnR/rYuUJRC0tmKpkZBb8kZVcbSChzkB/JYkBjBCzpQ==",
       "dev": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
-        "@storybook/types": "7.6.16",
+        "@storybook/types": "7.6.17",
         "jest-mock": "^27.0.6",
         "polished": "^4.2.2",
         "ts-dedent": "^2.2.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      }
-    },
-    "node_modules/@storybook/addon-interactions/node_modules/@storybook/channels": {
-      "version": "7.6.16",
-      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-7.6.16.tgz",
-      "integrity": "sha512-LKB0t4OGISez1O4TRJ/CDPxlb2wAW7gg8YRL91VVUHeffVyr4bnpklvMbLbuEcYrysM82Q2UMB9ipQdyK6Issg==",
-      "dev": true,
-      "dependencies": {
-        "@storybook/client-logger": "7.6.16",
-        "@storybook/core-events": "7.6.16",
-        "@storybook/global": "^5.0.0",
-        "qs": "^6.10.0",
-        "telejson": "^7.2.0",
-        "tiny-invariant": "^1.3.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      }
-    },
-    "node_modules/@storybook/addon-interactions/node_modules/@storybook/client-logger": {
-      "version": "7.6.16",
-      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-7.6.16.tgz",
-      "integrity": "sha512-Vquhmgk/SO0VeAkojcA1juuicBHoTST+f4XwBvyUNiebOSOdGIkxHVxpDFXu2kS0aKflFBEutX2IgoysDup+fQ==",
-      "dev": true,
-      "dependencies": {
-        "@storybook/global": "^5.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      }
-    },
-    "node_modules/@storybook/addon-interactions/node_modules/@storybook/core-events": {
-      "version": "7.6.16",
-      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-7.6.16.tgz",
-      "integrity": "sha512-mkBqzrbp6vmdjo0fBZGrFQQ4YdvMFxF6AesdKTf8EzPa69FoxnhQLrmQ4aXF+9vXkxfXVJF2HfpoTEdfqqAo+w==",
-      "dev": true,
-      "dependencies": {
-        "ts-dedent": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      }
-    },
-    "node_modules/@storybook/addon-interactions/node_modules/@storybook/types": {
-      "version": "7.6.16",
-      "resolved": "https://registry.npmjs.org/@storybook/types/-/types-7.6.16.tgz",
-      "integrity": "sha512-Ld4dKbgSbvqThdBNwNlOxQu5AiS6U9DXI5evf/j83eWs6skO3OBdQp+GWa6sUCI9eRqH8tFsw/YmMcIZ4uZrBQ==",
-      "dev": true,
-      "dependencies": {
-        "@storybook/channels": "7.6.16",
-        "@types/babel__core": "^7.0.0",
-        "@types/express": "^4.7.0",
-        "file-system-cache": "2.3.0"
       },
       "funding": {
         "type": "opencollective",


### PR DESCRIPTION
- Dependabot: Bump electron-to-chromium from 1.4.676 to 1.4.677
- Dependabot: Bump typed-array-byte-offset from 1.0.1 to 1.0.2
- Dependabot: Bump typed-array-byte-length from 1.0.0 to 1.0.1
- Dependabot: Bump typed-array-length from 1.0.4 to 1.0.5
- Dependabot: Bump preact-render-to-string from 6.3.1 to 6.4.0
- Dependabot: Bump is-negative-zero from 2.0.2 to 2.0.3
- Dependabot: Bump flatted from 3.3.0 to 3.3.1
- Dependabot: Bump vite from 5.1.3 to 5.1.4
- Dependabot: bump @storybook/addon-interactions from 7.6.16 to 7.6.17
