### PR TITLE
combine all dependabot prs 2024 02 23 7898

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19013,9 +19013,9 @@
       "dev": true
     },
     "node_modules/preact": {
-      "version": "10.19.5",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.19.5.tgz",
-      "integrity": "sha512-OPELkDmSVbKjbFqF9tgvOowiiQ9TmsJljIzXRyNE8nGiis94pwv1siF78rQkAP1Q1738Ce6pellRg/Ns/CtHqQ==",
+      "version": "10.19.6",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.19.6.tgz",
+      "integrity": "sha512-gympg+T2Z1fG1unB8NH29yHJwnEaCH37Z32diPDku316OTnRPeMbiRV9kTrfZpocXjdfnWuFUl/Mj4BHaf6gnw==",
       "dev": true,
       "funding": {
         "type": "opencollective",


### PR DESCRIPTION
- Dependabot: Bump @storybook/addon-essentials from 7.6.13 to 7.6.17
- Dependabot: Bump electron-to-chromium from 1.4.677 to 1.4.679
- Dependabot: Bump storybook from 7.6.16 to 7.6.17
- Dependabot: Bump jscodeshift from 0.15.1 to 0.15.2
- Dependabot: Bump caniuse-lite from 1.0.30001588 to 1.0.30001589
- Dependabot: Bump preact from 10.19.5 to 10.19.6
