### PR TITLE
combine all dependabot prs 2024 02 24 2487

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9470,9 +9470,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.679",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.679.tgz",
-      "integrity": "sha512-NhQMsz5k0d6m9z3qAxnsOR/ebal4NAGsrNVRwcDo4Kc/zQ7KdsTKZUxZoygHcVRb0QDW3waEDIcE3isZ79RP6g==",
+      "version": "1.4.681",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.681.tgz",
+      "integrity": "sha512-1PpuqJUFWoXZ1E54m8bsLPVYwIVCRzvaL+n5cjigGga4z854abDnFRc+cTa2th4S79kyGqya/1xoR7h+Y5G5lg==",
       "dev": true
     },
     "node_modules/emittery": {


### PR DESCRIPTION
- Dependabot: Bump tiny-invariant from 1.3.1 to 1.3.2
- Dependabot: Bump @types/chai from 4.3.11 to 4.3.12
- Dependabot: Bump @types/node from 18.19.17 to 18.19.18
- Dependabot: Bump electron-to-chromium from 1.4.679 to 1.4.681
- Dependabot: Bump es-set-tostringtag from 2.0.2 to 2.0.3
- Dependabot: Bump is-shared-array-buffer from 1.0.2 to 1.0.3
