### PR TITLE
combine all dependabot prs 2024 02 28 7219

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9491,9 +9491,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.681",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.681.tgz",
-      "integrity": "sha512-1PpuqJUFWoXZ1E54m8bsLPVYwIVCRzvaL+n5cjigGga4z854abDnFRc+cTa2th4S79kyGqya/1xoR7h+Y5G5lg==",
+      "version": "1.4.685",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.685.tgz",
+      "integrity": "sha512-yDYeobbTEe4TNooEzOQO6xFqg9XnAkVy2Lod1C1B2it8u47JNLYvl9nLDWBamqUakWB8Jc1hhS1uHUNYTNQdfw==",
       "dev": true
     },
     "node_modules/emittery": {


### PR DESCRIPTION
- Dependabot: Bump caniuse-lite from 1.0.30001589 to 1.0.30001591
- Dependabot: Bump @types/react from 18.2.57 to 18.2.60
- Dependabot: Bump @babel/runtime from 7.23.9 to 7.24.0
- Dependabot: Bump @babel/preset-env from 7.23.9 to 7.24.0
- Dependabot: Bump object-is from 1.1.5 to 1.1.6
- Dependabot: Bump @babel/core from 7.23.9 to 7.24.0
- Dependabot: Bump @types/node from 18.19.18 to 18.19.19
- Dependabot: Bump @babel/helper-create-class-features-plugin
- Dependabot: Bump @babel/plugin-transform-object-rest-spread
- Dependabot: Bump @babel/helpers from 7.23.9 to 7.24.0
- Dependabot: Bump @babel/preset-flow from 7.23.3 to 7.24.0
- Dependabot: Bump @types/qs from 6.9.11 to 6.9.12
- Dependabot: Bump @babel/template from 7.23.9 to 7.24.0
- Dependabot: Bump @babel/helper-plugin-utils from 7.22.5 to 7.24.0
- Dependabot: Bump @babel/types from 7.23.9 to 7.24.0
- Dependabot: Bump @babel/parser from 7.23.9 to 7.24.0
- Dependabot: Bump electron-to-chromium from 1.4.681 to 1.4.685
