### PR TITLE
combine all dependabot prs 2024 02 29 8767

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3655,9 +3655,9 @@
       }
     },
     "node_modules/@jridgewell/set-array": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
       "dev": true,
       "engines": {
         "node": ">=6.0.0"


### PR DESCRIPTION
- Dependabot: Bump @types/node from 18.19.19 to 18.19.20
- Dependabot: Bump electron-to-chromium from 1.4.685 to 1.4.687
- Dependabot: Bump es-abstract from 1.22.4 to 1.22.5
- Dependabot: Bump express from 4.18.2 to 4.18.3
- Dependabot: Bump @jridgewell/set-array from 1.1.2 to 1.2.1
