### PR TITLE
combine all dependabot prs 2024 03 01 4682

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6701,9 +6701,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "18.2.60",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.60.tgz",
-      "integrity": "sha512-dfiPj9+k20jJrLGOu9Nf6eqxm2EyJRrq2NvwOFsfbb7sFExZ9WELPs67UImHj3Ayxg8ruTtKtNnbjaF8olPq0A==",
+      "version": "18.2.61",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.61.tgz",
+      "integrity": "sha512-NURTN0qNnJa7O/k4XUkEW2yfygA+NxS0V5h1+kp9jPwhzZy95q3ADoGMP0+JypMhrZBTTgjKAUlTctde1zzeQA==",
       "dev": true,
       "dependencies": {
         "@types/prop-types": "*",


### PR DESCRIPTION
- Dependabot: Bump @types/node from 18.19.19 to 18.19.21
- Dependabot: Bump side-channel from 1.0.5 to 1.0.6
- Dependabot: Bump @jridgewell/trace-mapping from 0.3.23 to 0.3.24
- Dependabot: Bump @ampproject/remapping from 2.2.1 to 2.3.0
- Dependabot: Bump electron-to-chromium from 1.4.687 to 1.4.689
- Dependabot: Bump @jridgewell/gen-mapping from 0.3.4 to 0.3.5
- Dependabot: Bump @types/react from 18.2.60 to 18.2.61
