### PR TITLE
Introduce basic terminology modal

### DIFF
--- a/src/components/Content/index.js
+++ b/src/components/Content/index.js
@@ -14,7 +14,7 @@ export const prepareClickableWords = ({ text, action }) => {
     return isClickable ? (
       <>
         {specialCharPosition == 0 ? `${specialChars[0]} ` : ''}
-        <span key={`clickable-${word}-${index}`} style={{ color: '#f00', cursor: 'pointer' }} onClick={() => action({ word })}>
+        <span key={`clickable-${word}-${index}`} style={{ color: '#f00', cursor: 'pointer' }} onClick={() => action({ word: word.replaceAll(/[.,()]/g, '') })}>
           {wordWithPostfix}
         </span>
         {specialCharPosition ? `${specialChars[0]} ` : ''}

--- a/src/components/Hanafiyyah/en/Hayd/index.stories.js
+++ b/src/components/Hanafiyyah/en/Hayd/index.stories.js
@@ -2,10 +2,7 @@ import { Hayd } from '@components/Hanafiyyah/en/Hayd';
 
 export default {
   title: 'Hayd',
-  component: Hayd,
-  argTypes: {
-    action: { action: 'action' }
-  }
+  component: Hayd
 };
 
 const Template = (args) => (<Hayd {...args} />);
@@ -34,4 +31,10 @@ Default.args = {
   clarificationIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png',
   ramadanIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png',
   marriageIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png'
+};
+
+export const overrideAction = Template.bind({});
+overrideAction.args = Default.args;
+overrideAction.argTypes = {
+  action: { action: 'action' }
 };

--- a/src/components/Hanafiyyah/en/Indeterminate/index.stories.js
+++ b/src/components/Hanafiyyah/en/Indeterminate/index.stories.js
@@ -4,7 +4,6 @@ export default {
   title: 'Indeterminate',
   component: Indeterminate,
   argTypes: {
-    action: { action: 'action' },
     scenario: {
       options: ['subsequent-bleedings', 'initial-bleeding', 'present-cycle'],
       control: { type: 'radio' }
@@ -39,4 +38,10 @@ Default.args = {
   clarificationIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png',
   ramadanIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png',
   marriageIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png'
+};
+
+export const overrideAction = Template.bind({});
+overrideAction.args = Default.args;
+overrideAction.argTypes = {
+  action: { action: 'action' }
 };

--- a/src/components/Hanafiyyah/en/Istihadah/index.stories.js
+++ b/src/components/Hanafiyyah/en/Istihadah/index.stories.js
@@ -2,10 +2,7 @@ import { Istihadah } from '@components/Hanafiyyah/en/Istihadah';
 
 export default {
   title: 'Istihadah',
-  component: Istihadah,
-  argTypes: {
-    action: { action: 'action' }
-  }
+  component: Istihadah
 };
 
 const Template = (args) => (<Istihadah {...args} />);
@@ -34,4 +31,10 @@ Default.args = {
   clarificationIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png',
   ramadanIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png',
   marriageIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png'
+};
+
+export const overrideAction = Template.bind({});
+overrideAction.args = Default.args;
+overrideAction.argTypes = {
+  action: { action: 'action' }
 };

--- a/src/components/Hanafiyyah/en/MostLikelyHayd/index.stories.js
+++ b/src/components/Hanafiyyah/en/MostLikelyHayd/index.stories.js
@@ -2,10 +2,7 @@ import { MostLikelyHayd } from '@components/Hanafiyyah/en/MostLikelyHayd';
 
 export default {
   title: 'MostLikelyHayd',
-  component: MostLikelyHayd,
-  argTypes: {
-    action: { action: 'action' }
-  }
+  component: MostLikelyHayd
 };
 
 const Template = (args) => (<MostLikelyHayd {...args} />);
@@ -34,4 +31,10 @@ Default.args = {
   clarificationIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png',
   ramadanIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png',
   marriageIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png'
+};
+
+export const overrideAction = Template.bind({});
+overrideAction.args = Default.args;
+overrideAction.argTypes = {
+  action: { action: 'action' }
 };

--- a/src/components/Hanafiyyah/en/MostLikelyIstihadah/index.stories.js
+++ b/src/components/Hanafiyyah/en/MostLikelyIstihadah/index.stories.js
@@ -2,10 +2,7 @@ import { MostLikelyIstihadah } from '@components/Hanafiyyah/en/MostLikelyIstihad
 
 export default {
   title: 'MostLikelyIstihadah',
-  component: MostLikelyIstihadah,
-  argTypes: {
-    action: { action: 'action' }
-  }
+  component: MostLikelyIstihadah
 };
 
 const Template = (args) => (<MostLikelyIstihadah {...args} />);
@@ -34,4 +31,10 @@ Default.args = {
   clarificationIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png',
   ramadanIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png',
   marriageIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png'
+};
+
+export const overrideAction = Template.bind({});
+overrideAction.args = Default.args;
+overrideAction.argTypes = {
+  action: { action: 'action' }
 };

--- a/src/components/Hanafiyyah/en/MostLikelyTuhr/index.stories.js
+++ b/src/components/Hanafiyyah/en/MostLikelyTuhr/index.stories.js
@@ -4,7 +4,6 @@ export default {
   title: 'MostLikelyTuhr',
   component: MostLikelyTuhr,
   argTypes: {
-    action: { action: 'action' },
     scenario: {
       options: ['before-habit', 'before-10-days'],
       control: { type: 'radio' }
@@ -39,4 +38,10 @@ Default.args = {
   clarificationIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png',
   ramadanIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png',
   marriageIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png'
+};
+
+export const overrideAction = Template.bind({});
+overrideAction.args = Default.args;
+overrideAction.argTypes = {
+  action: { action: 'action' }
 };

--- a/src/components/Hanafiyyah/en/OngoingHayd/index.stories.js
+++ b/src/components/Hanafiyyah/en/OngoingHayd/index.stories.js
@@ -4,7 +4,6 @@ export default {
   title: 'OngoingHayd',
   component: OngoingHayd,
   argTypes: {
-    action: { action: 'action' },
     scenario: {
       options: ['until-habit', 'until-10-days'],
       control: { type: 'radio' }
@@ -39,4 +38,10 @@ Default.args = {
   clarificationIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png',
   ramadanIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png',
   marriageIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png'
+};
+
+export const overrideAction = Template.bind({});
+overrideAction.args = Default.args;
+overrideAction.argTypes = {
+  action: { action: 'action' }
 };

--- a/src/components/Hanafiyyah/en/Tuhr/index.stories.js
+++ b/src/components/Hanafiyyah/en/Tuhr/index.stories.js
@@ -4,7 +4,6 @@ export default {
   title: 'Tuhr',
   component: Tuhr,
   argTypes: {
-    action: { action: 'action' },
     scenario: {
       options: ['complete', 'concludes-excess-10-day-bleeding'],
       control: { type: 'radio' }
@@ -39,4 +38,10 @@ Default.args = {
   clarificationIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png',
   ramadanIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png',
   marriageIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png'
+};
+
+export const overrideAction = Template.bind({});
+overrideAction.args = Default.args;
+overrideAction.argTypes = {
+  action: { action: 'action' }
 };

--- a/src/components/Hidayah/index.js
+++ b/src/components/Hidayah/index.js
@@ -2,11 +2,27 @@
 import { Title, Clarification, Guidance, Marriage, Ramadan } from '@components/Content';
 import { useMemo, useState } from 'preact/hooks';
 import PropTypes from 'prop-types';
+import terminologies from '@components/Content/terminologies.json';
+import { Fragment } from 'preact';
+
+const PopUpModal = ({ popUpClassName, displayPopUpModal, setDisplayPopUpModal, popUpModalWord }) => {
+  if ( !displayPopUpModal ) {
+    return <></>;
+  }
+
+  return (<div style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%', padding: '1%', backgroundColor: '#ddd' }} className={popUpClassName}>
+    <h3>{popUpModalWord} {`(${terminologies[popUpModalWord.toLowerCase()]})`}</h3>
+    <p>Description/Explanation coming soon inshallah</p>
+    <button style={{ position: 'absolute', top: '1%', right: '1%' }} onClick={() => setDisplayPopUpModal(false)}>X</button>
+  </div>);
+};
 
 const Hidayah = ({ content, action, style, className, tabsContainerClassName, tabClassName, contentClassName,
-  showTabsIcons=true, showTabsTitle=true, showTitle=true, showInnerTitle=true, guidanceIcon,
-  clarificationIcon, ramadanIcon, marriageIcon } = {}) => {
+  popUpClassName, showTabsIcons=true, showTabsTitle=true, showTitle=true, showInnerTitle=true,
+  guidanceIcon, clarificationIcon, ramadanIcon, marriageIcon } = {}) => {
   const [activeTab, setActiveTab] = useState('Guidance');
+  const [displayPopUpModal, setDisplayPopUpModal] = useState();
+  const [popUpModalWord, setPopUpModalTerm] = useState();
   const tabs = useMemo(() => (['Guidance', 'Clarification', 'Ramadan', 'Marriage']), []);
 
   const getIcon = ({ tab }) => {
@@ -22,6 +38,11 @@ const Hidayah = ({ content, action, style, className, tabsContainerClassName, ta
     default:
       throw new Error(`[Developer Error] No icon provided for the tab: "${tab}". Make sure pass the right tab name`);
     }
+  };
+
+  const alternativeAction = ({ word }) => {
+    setDisplayPopUpModal(true);
+    setPopUpModalTerm(word);
   };
 
   const handleTabClick = (tab) => setActiveTab(tab);
@@ -41,11 +62,13 @@ const Hidayah = ({ content, action, style, className, tabsContainerClassName, ta
           </button>
         ))}
       </div>
+      {/* eslint-disable-next-line max-len */}
+      <PopUpModal popUpClassName={popUpClassName} displayPopUpModal={displayPopUpModal} popUpModalWord={popUpModalWord} setDisplayPopUpModal={setDisplayPopUpModal} />
       <div className={contentClassName || ''}>
-        {activeTab === 'Guidance' && <Guidance action={action} text={content.guidance} showInnerTitle={showInnerTitle} />}
-        {activeTab === 'Clarification' && <Clarification action={action} text={content.additionalClarifications} showInnerTitle={showInnerTitle} />}
-        {activeTab === 'Ramadan' && <Ramadan action={action} text={content.ramadanClarifications} showInnerTitle={showInnerTitle} />}
-        {activeTab === 'Marriage' && <Marriage action={action} text={content.maritalClarifications} showInnerTitle={showInnerTitle} />}
+        {activeTab === 'Guidance' && <Guidance action={action ? action : alternativeAction} text={content.guidance} showInnerTitle={showInnerTitle} />}
+        {activeTab === 'Clarification' && <Clarification action={action ? action : alternativeAction} text={content.additionalClarifications} showInnerTitle={showInnerTitle} />}
+        {activeTab === 'Ramadan' && <Ramadan action={action ? action : alternativeAction} text={content.ramadanClarifications} showInnerTitle={showInnerTitle} />}
+        {activeTab === 'Marriage' && <Marriage action={action ? action : alternativeAction} text={content.maritalClarifications} showInnerTitle={showInnerTitle} />}
       </div>
     </div>
   );


### PR DESCRIPTION
* Introduce basic pop up modal when clicking on a terminology word.
* Fix word that is sent to the action, as it was sent with extra chars like `.()/` etc. .
* Add extra storybook for each component to allow users to see that they can override action.


https://github.com/al-mabsut/muslimah/assets/37546491/476bb800-7af5-47c7-adb5-cf6a7a100f17

