### PR TITLE
Bump version 0.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@al-mabsut/muslimah",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@al-mabsut/muslimah",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "ISC",
       "devDependencies": {
         "@babel/core": "^7.23.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al-mabsut/muslimah",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Shari' ahkaam related to muslim women matters",
   "main": "dist/cjs/bundle.js",
   "module": "dist/esm/bundle.js",


### PR DESCRIPTION
In this new version we have :

* Introduced basic pop up modal when clicking on a terminology word.
* Fixed word that is sent to the action, as it was sent with extra chars like `.()/` etc. .
* Added extra storybook for each component to allow users to see that they can override action.
* Added more terminologies
* Changed terminologies structure to contain the level (level represents the minimal level required to have a reasonable expectation that such a person is familiar with the word and its implications.) and `en` translation for now.