### PR TITLE
combine all dependabot prs 2024 03 04 3723

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8185,9 +8185,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001591",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001591.tgz",
-      "integrity": "sha512-PCzRMei/vXjJyL5mJtzNiUCKP59dm8Apqc3PH8gJkMnMXZGox93RbE76jHsmLwmIo6/3nsYIpJtx0O7u5PqFuQ==",
+      "version": "1.0.30001593",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001593.tgz",
+      "integrity": "sha512-UWM1zlo3cZfkpBysd7AS+z+v007q9G1+fLTUU42rQnY6t2axoogPW/xol6T7juU5EUoOhML4WgBIdG+9yYqAjQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
- Dependabot: Bump eslint-plugin-react from 7.33.2 to 7.34.0
- Dependabot: Bump nypm from 0.3.6 to 0.3.8
- Dependabot: Bump @jridgewell/trace-mapping from 0.3.24 to 0.3.25
- Dependabot: Bump caniuse-lite from 1.0.30001591 to 1.0.30001593
