### PR TITLE
combine all dependabot prs 2024 03 06 9101

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8216,9 +8216,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001593",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001593.tgz",
-      "integrity": "sha512-UWM1zlo3cZfkpBysd7AS+z+v007q9G1+fLTUU42rQnY6t2axoogPW/xol6T7juU5EUoOhML4WgBIdG+9yYqAjQ==",
+      "version": "1.0.30001594",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001594.tgz",
+      "integrity": "sha512-VblSX6nYqyJVs8DKFMldE2IVCJjZ225LW00ydtUWwh5hk9IfkTOffO6r8gJNsH0qqqeAF8KrbMYA2VEwTlGW5g==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
- Dependabot: Bump @types/react from 18.2.61 to 18.2.63
- Dependabot: Bump recast from 0.23.4 to 0.23.5
- Dependabot: Bump electron-to-chromium from 1.4.689 to 1.4.692
- Dependabot: Bump vite from 5.1.4 to 5.1.5
- Dependabot: Bump unplugin from 1.7.1 to 1.8.1
- Dependabot: Bump caniuse-lite from 1.0.30001593 to 1.0.30001594
