### PR TITLE
combine all dependabot prs 2024 03 06 10507

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19689,9 +19689,9 @@
       }
     },
     "node_modules/unplugin": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-1.8.1.tgz",
-      "integrity": "sha512-NDAvOEnZmeSRRmjfD0FoLzfve2/9lqceO5bR4J/2V72zphnFdq7UYo3fg6F1y1HfZEaSHa+7bZgbEN+z5x8ZDQ==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-1.8.2.tgz",
+      "integrity": "sha512-fgldo8hwP8dV94ne3rwQqlZkZWdcqH4K48bXax+N0MrBapfvoTbIQt9L2Vj/DzZAbWI/+kd2b9ZDsB7QZgz/hw==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.11.3",


### PR DESCRIPTION
- Dependabot: Bump electron-to-chromium from 1.4.692 to 1.4.693
- Dependabot: Bump unplugin from 1.8.1 to 1.8.2
