### PR TITLE
combine all dependabot prs 2024 03 11 9182

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8216,9 +8216,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001596",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001596.tgz",
-      "integrity": "sha512-zpkZ+kEr6We7w63ORkoJ2pOfBwBkY/bJrG/UZ90qNb45Isblu8wzDgevEOrRL1r9dWayHjYiiyCMEXPn4DweGQ==",
+      "version": "1.0.30001597",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001597.tgz",
+      "integrity": "sha512-7LjJvmQU6Sj7bL0j5b5WY/3n7utXUJvAe1lxhsHDbLmwX9mdL86Yjtr+5SRCyf8qME4M7pU2hswj0FpyBVCv9w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
- Dependabot: Bump electron-to-chromium from 1.4.698 to 1.4.699
- Dependabot: Bump unplugin from 1.8.3 to 1.9.0
- Dependabot: Bump is-set from 2.0.2 to 2.0.3
- Dependabot: Bump babel-plugin-polyfill-corejs2 from 0.4.8 to 0.4.9
- Dependabot: Bump which-typed-array from 1.1.14 to 1.1.15
- Dependabot: Bump is-map from 2.0.2 to 2.0.3
- Dependabot: Bump is-weakmap from 2.0.1 to 2.0.2
- Dependabot: Bump is-weakset from 2.0.2 to 2.0.3
- Dependabot: Bump set-function-length from 1.2.1 to 1.2.2
- Dependabot: Bump which-collection from 1.0.1 to 1.0.2
- Dependabot: Bump safe-array-concat from 1.1.0 to 1.1.2
- Dependabot: Bump recast from 0.23.5 to 0.23.6
- Dependabot: Bump hasown from 2.0.1 to 2.0.2
- Dependabot: Bump caniuse-lite from 1.0.30001596 to 1.0.30001597
