### PR TITLE
Downgrade storybook/preact-vite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@storybook/addon-links": "^8.0.0",
         "@storybook/blocks": "^7.6.6",
         "@storybook/preact": "^8.0.0",
-        "@storybook/preact-vite": "^8.0.0",
+        "@storybook/preact-vite": "^7.6.6",
         "@storybook/test": "^8.0.0",
         "@testing-library/preact": "^3.2.3",
         "babel-jest": "^29.7.0",
@@ -3779,6 +3779,92 @@
       "integrity": "sha512-j7P6Rgr3mmtdkeDGTe0E/aYyWEWVtc5yFXtHCRHs28/jptDEWfaVOc5T7cblqy1XKPPfCxJc/8DwQ5YgLOZOVQ==",
       "dev": true
     },
+    "node_modules/@preact/preset-vite": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@preact/preset-vite/-/preset-vite-2.8.1.tgz",
+      "integrity": "sha512-a9KV4opdj17X2gOFuGup0aE+sXYABX/tJi/QDptOrleX4FlnoZgDWvz45tHOdVfrZX+3uvVsIYPHxRsTerkDNA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/plugin-transform-react-jsx": "^7.22.15",
+        "@babel/plugin-transform-react-jsx-development": "^7.22.5",
+        "@prefresh/vite": "^2.4.1",
+        "@rollup/pluginutils": "^4.1.1",
+        "babel-plugin-transform-hook-names": "^1.0.2",
+        "debug": "^4.3.4",
+        "kolorist": "^1.8.0",
+        "magic-string": "0.30.5",
+        "node-html-parser": "^6.1.10",
+        "resolve": "^1.22.8"
+      },
+      "peerDependencies": {
+        "@babel/core": "7.x",
+        "vite": "2.x || 3.x || 4.x || 5.x"
+      }
+    },
+    "node_modules/@preact/preset-vite/node_modules/@rollup/pluginutils": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
+      "integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
+      "dev": true,
+      "dependencies": {
+        "estree-walker": "^2.0.1",
+        "picomatch": "^2.2.2"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/@prefresh/babel-plugin": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@prefresh/babel-plugin/-/babel-plugin-0.5.1.tgz",
+      "integrity": "sha512-uG3jGEAysxWoyG3XkYfjYHgaySFrSsaEb4GagLzYaxlydbuREtaX+FTxuIidp241RaLl85XoHg9Ej6E4+V1pcg==",
+      "dev": true
+    },
+    "node_modules/@prefresh/core": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@prefresh/core/-/core-1.5.2.tgz",
+      "integrity": "sha512-A/08vkaM1FogrCII5PZKCrygxSsc11obExBScm3JF1CryK2uDS3ZXeni7FeKCx1nYdUkj4UcJxzPzc1WliMzZA==",
+      "dev": true,
+      "peerDependencies": {
+        "preact": "^10.0.0"
+      }
+    },
+    "node_modules/@prefresh/utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@prefresh/utils/-/utils-1.2.0.tgz",
+      "integrity": "sha512-KtC/fZw+oqtwOLUFM9UtiitB0JsVX0zLKNyRTA332sqREqSALIIQQxdUCS1P3xR/jT1e2e8/5rwH6gdcMLEmsQ==",
+      "dev": true
+    },
+    "node_modules/@prefresh/vite": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@prefresh/vite/-/vite-2.4.5.tgz",
+      "integrity": "sha512-iForDVJ2M8gQYnm5pHumvTEJjGGc7YNYC0GVKnHFL+GvFfKHfH9Rpq67nUAzNbjuLEpqEOUuQVQajMazWu2ZNQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.22.1",
+        "@prefresh/babel-plugin": "0.5.1",
+        "@prefresh/core": "^1.5.1",
+        "@prefresh/utils": "^1.2.0",
+        "@rollup/pluginutils": "^4.2.1"
+      },
+      "peerDependencies": {
+        "preact": "^10.4.0",
+        "vite": ">=2.0.0"
+      }
+    },
+    "node_modules/@prefresh/vite/node_modules/@rollup/pluginutils": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
+      "integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
+      "dev": true,
+      "dependencies": {
+        "estree-walker": "^2.0.1",
+        "picomatch": "^2.2.2"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/@radix-ui/number": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.0.1.tgz",
@@ -5058,20 +5144,19 @@
       }
     },
     "node_modules/@storybook/builder-vite": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-8.0.0.tgz",
-      "integrity": "sha512-dJhd8QwQDELwStbM1P6LEXjFHVbhMM4jH5L+UkDDrS42m2YTvizdGhyRvEJajLz1Ar7o4++p2hBBA/dU9NXfJQ==",
+      "version": "7.6.17",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-7.6.17.tgz",
+      "integrity": "sha512-2Q32qalI401EsKKr9Hkk8TAOcHEerqwsjCpQgTNJnCu6GgCVKoVUcb99oRbR9Vyg0xh+jb19XiWqqQujFtLYlQ==",
       "dev": true,
       "dependencies": {
-        "@storybook/channels": "8.0.0",
-        "@storybook/client-logger": "8.0.0",
-        "@storybook/core-common": "8.0.0",
-        "@storybook/core-events": "8.0.0",
-        "@storybook/csf-plugin": "8.0.0",
-        "@storybook/node-logger": "8.0.0",
-        "@storybook/preview": "8.0.0",
-        "@storybook/preview-api": "8.0.0",
-        "@storybook/types": "8.0.0",
+        "@storybook/channels": "7.6.17",
+        "@storybook/client-logger": "7.6.17",
+        "@storybook/core-common": "7.6.17",
+        "@storybook/csf-plugin": "7.6.17",
+        "@storybook/node-logger": "7.6.17",
+        "@storybook/preview": "7.6.17",
+        "@storybook/preview-api": "7.6.17",
+        "@storybook/types": "7.6.17",
         "@types/find-cache-dir": "^3.2.1",
         "browser-assert": "^1.2.1",
         "es-module-lexer": "^0.9.3",
@@ -5079,7 +5164,7 @@
         "find-cache-dir": "^3.0.0",
         "fs-extra": "^11.1.0",
         "magic-string": "^0.30.0",
-        "ts-dedent": "^2.0.0"
+        "rollup": "^2.25.0 || ^3.3.0"
       },
       "funding": {
         "type": "opencollective",
@@ -5088,7 +5173,7 @@
       "peerDependencies": {
         "@preact/preset-vite": "*",
         "typescript": ">= 4.3.x",
-        "vite": "^4.0.0 || ^5.0.0",
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0",
         "vite-plugin-glimmerx": "*"
       },
       "peerDependenciesMeta": {
@@ -5103,305 +5188,21 @@
         }
       }
     },
-    "node_modules/@storybook/builder-vite/node_modules/@storybook/channels": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-8.0.0.tgz",
-      "integrity": "sha512-uykCBlSIMVodsgTFC/XAgO7JeaTJrKtDmmM6Z4liGkPS6EUvurOEu2vK6FuvojzhLHdVJ5bP+VXSJerfm7aE4Q==",
+    "node_modules/@storybook/builder-vite/node_modules/rollup": {
+      "version": "3.29.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.4.tgz",
+      "integrity": "sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==",
       "dev": true,
-      "dependencies": {
-        "@storybook/client-logger": "8.0.0",
-        "@storybook/core-events": "8.0.0",
-        "@storybook/global": "^5.0.0",
-        "telejson": "^7.2.0",
-        "tiny-invariant": "^1.3.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      }
-    },
-    "node_modules/@storybook/builder-vite/node_modules/@storybook/client-logger": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-8.0.0.tgz",
-      "integrity": "sha512-olc1vUfaZNkXc7L8UoCdGmyBieHQbsaB+0vVoivYMSa1DHYtXE75RefU3lhMSGrkvIZmXMvfaIDmnyJIOB5FxA==",
-      "dev": true,
-      "dependencies": {
-        "@storybook/global": "^5.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      }
-    },
-    "node_modules/@storybook/builder-vite/node_modules/@storybook/core-common": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@storybook/core-common/-/core-common-8.0.0.tgz",
-      "integrity": "sha512-fqlQYw5/PDW/oj34QwU5u0HkNLPgELfszsvLFsUcwI7uAzwb/WC2WdPvncT7qRPNcSZLXKJcA8QAqKL4t4I8bg==",
-      "dev": true,
-      "dependencies": {
-        "@storybook/core-events": "8.0.0",
-        "@storybook/csf-tools": "8.0.0",
-        "@storybook/node-logger": "8.0.0",
-        "@storybook/types": "8.0.0",
-        "@yarnpkg/fslib": "2.10.3",
-        "@yarnpkg/libzip": "2.3.0",
-        "chalk": "^4.1.0",
-        "cross-spawn": "^7.0.3",
-        "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0",
-        "esbuild-register": "^3.5.0",
-        "execa": "^5.0.0",
-        "file-system-cache": "2.3.0",
-        "find-cache-dir": "^3.0.0",
-        "find-up": "^5.0.0",
-        "fs-extra": "^11.1.0",
-        "glob": "^10.0.0",
-        "handlebars": "^4.7.7",
-        "lazy-universal-dotenv": "^4.0.0",
-        "node-fetch": "^2.0.0",
-        "picomatch": "^2.3.0",
-        "pkg-dir": "^5.0.0",
-        "pretty-hrtime": "^1.0.3",
-        "resolve-from": "^5.0.0",
-        "semver": "^7.3.7",
-        "tempy": "^1.0.1",
-        "tiny-invariant": "^1.3.1",
-        "ts-dedent": "^2.0.0",
-        "util": "^0.12.4"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      }
-    },
-    "node_modules/@storybook/builder-vite/node_modules/@storybook/core-events": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-8.0.0.tgz",
-      "integrity": "sha512-kkabj4V99gOTBW+y3HM/LTCDekglqb+lslZMamM+Ytxv1lCqCEOIR/OGfnYOyEaK4BLcx61Zp+fO30FZxtoT1w==",
-      "dev": true,
-      "dependencies": {
-        "ts-dedent": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      }
-    },
-    "node_modules/@storybook/builder-vite/node_modules/@storybook/csf-plugin": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-8.0.0.tgz",
-      "integrity": "sha512-bCX3XvZ8X1dS08ung0IhugtTUOK+rWwRjWjyj5WC7fl5HYyFYQ91MC2f8EccYQaDYl9Dfvo1cw685gnk6PoLbw==",
-      "dev": true,
-      "dependencies": {
-        "@storybook/csf-tools": "8.0.0",
-        "unplugin": "^1.3.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      }
-    },
-    "node_modules/@storybook/builder-vite/node_modules/@storybook/csf-tools": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@storybook/csf-tools/-/csf-tools-8.0.0.tgz",
-      "integrity": "sha512-VIMaZJiGM2NVzlgxaOyaVlH1pw/VSrJygDqOZyANh/kl4KHA+6xIqOkZC+X0+5K295dTFx2nR6S3btTjwT/Wrg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/generator": "^7.23.0",
-        "@babel/parser": "^7.23.0",
-        "@babel/traverse": "^7.23.2",
-        "@babel/types": "^7.23.0",
-        "@storybook/csf": "^0.1.2",
-        "@storybook/types": "8.0.0",
-        "fs-extra": "^11.1.0",
-        "recast": "^0.23.5",
-        "ts-dedent": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      }
-    },
-    "node_modules/@storybook/builder-vite/node_modules/@storybook/node-logger": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-8.0.0.tgz",
-      "integrity": "sha512-C/sMNQqCIYVtJaLpe92RSkPgW3GXcWp6QeH5+glfP42kh+G9axxnEJJ996tyAnNQRzUuI+Eh+B7ytPZU1/WseQ==",
-      "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      }
-    },
-    "node_modules/@storybook/builder-vite/node_modules/@storybook/preview-api": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@storybook/preview-api/-/preview-api-8.0.0.tgz",
-      "integrity": "sha512-R2NBKtvHi+i1b/3PZe4u4YdJ7dlqr8YTqLn7syB/YSnKRAa7DYed+GJLu4qFJisE6IuYi+57AsdW16otRFEVvg==",
-      "dev": true,
-      "dependencies": {
-        "@storybook/channels": "8.0.0",
-        "@storybook/client-logger": "8.0.0",
-        "@storybook/core-events": "8.0.0",
-        "@storybook/csf": "^0.1.2",
-        "@storybook/global": "^5.0.0",
-        "@storybook/types": "8.0.0",
-        "@types/qs": "^6.9.5",
-        "dequal": "^2.0.2",
-        "lodash": "^4.17.21",
-        "memoizerific": "^1.11.3",
-        "qs": "^6.10.0",
-        "tiny-invariant": "^1.3.1",
-        "ts-dedent": "^2.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      }
-    },
-    "node_modules/@storybook/builder-vite/node_modules/@storybook/types": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@storybook/types/-/types-8.0.0.tgz",
-      "integrity": "sha512-6nJipdgoAkVFk2JpRPCm9vb/Yuak2lmdZRv9qzl8cNRttlbOESVlzbmhgxCmWV0OYUaMeYge9L8NWhJ14LKbzw==",
-      "dev": true,
-      "dependencies": {
-        "@storybook/channels": "8.0.0",
-        "@types/express": "^4.7.0",
-        "file-system-cache": "2.3.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      }
-    },
-    "node_modules/@storybook/builder-vite/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@storybook/builder-vite/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@storybook/builder-vite/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@storybook/builder-vite/node_modules/glob": {
-      "version": "10.3.10",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
-      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
-      "dev": true,
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^2.3.5",
-        "minimatch": "^9.0.1",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
-        "path-scurry": "^1.10.1"
-      },
       "bin": {
-        "glob": "dist/esm/bin.mjs"
+        "rollup": "dist/bin/rollup"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": ">=14.18.0",
+        "npm": ">=8.0.0"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
       }
-    },
-    "node_modules/@storybook/builder-vite/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@storybook/builder-vite/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@storybook/builder-vite/node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@storybook/builder-vite/node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@storybook/builder-vite/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@storybook/builder-vite/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
     },
     "node_modules/@storybook/channels": {
       "version": "7.6.17",
@@ -5625,6 +5426,20 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@storybook/core-client": {
+      "version": "7.6.17",
+      "resolved": "https://registry.npmjs.org/@storybook/core-client/-/core-client-7.6.17.tgz",
+      "integrity": "sha512-LuDbADK+DPNAOOCXOlvY09hdGVueXlDetsdOJ/DgYnSa9QSWv9Uv+F8QcEgR3QckZJbPlztKJIVLgP2n/Xkijw==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "7.6.17",
+        "@storybook/preview-api": "7.6.17"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
       }
     },
     "node_modules/@storybook/core-common": {
@@ -6192,16 +6007,17 @@
       }
     },
     "node_modules/@storybook/preact-vite": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@storybook/preact-vite/-/preact-vite-8.0.0.tgz",
-      "integrity": "sha512-u/5w772VwXa/8e5XIKKtI0zzK6BWYpfNtduIOPMIQdy/aZ7geC8o4PjHvzQ3oDY8a0XuTq7qTCt3H0I68bPPsA==",
+      "version": "7.6.17",
+      "resolved": "https://registry.npmjs.org/@storybook/preact-vite/-/preact-vite-7.6.17.tgz",
+      "integrity": "sha512-ZPOAxx7xBJ85L4PR+JkYiQcmoIXkEpZYkTXPyx331owBqWEos9hdf0WfVtnBa57fDwsbkKGY+uhmqbPrYPa5eA==",
       "dev": true,
       "dependencies": {
-        "@storybook/builder-vite": "8.0.0",
-        "@storybook/preact": "8.0.0"
+        "@preact/preset-vite": "^2.0.0",
+        "@storybook/builder-vite": "7.6.17",
+        "@storybook/preact": "7.6.17"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16"
       },
       "funding": {
         "type": "opencollective",
@@ -6209,7 +6025,30 @@
       },
       "peerDependencies": {
         "preact": ">=10",
-        "vite": "^4.0.0 || ^5.0.0"
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0"
+      }
+    },
+    "node_modules/@storybook/preact-vite/node_modules/@storybook/preact": {
+      "version": "7.6.17",
+      "resolved": "https://registry.npmjs.org/@storybook/preact/-/preact-7.6.17.tgz",
+      "integrity": "sha512-12F5rAJdqiLZ677VfuCB9lerfZV4H0y8ai03x0rHI53a23O/7GIkzII4JwE0KgWrBPDp8KNv4Q26DsCnqulpjw==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/core-client": "7.6.17",
+        "@storybook/global": "^5.0.0",
+        "@storybook/preview-api": "7.6.17",
+        "@storybook/types": "7.6.17",
+        "ts-dedent": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "preact": "^8.0.0||^10.0.0"
       }
     },
     "node_modules/@storybook/preact/node_modules/@storybook/channels": {
@@ -6297,9 +6136,9 @@
       }
     },
     "node_modules/@storybook/preview": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@storybook/preview/-/preview-8.0.0.tgz",
-      "integrity": "sha512-cFV7+6LYe1qr1HXm+oc74Z6ygAKgkjkhfGsfDhdS+UrzoFL9JF/+++RcE+xSBNVfzZjL19U1CsPEN0v0smIbkQ==",
+      "version": "7.6.17",
+      "resolved": "https://registry.npmjs.org/@storybook/preview/-/preview-7.6.17.tgz",
+      "integrity": "sha512-LvkMYK/y6alGjwRVNDIKL1lFlbyZ0H0c8iAbcQkiMoaFiujMQyVswMDKlWcj42Upfr/B1igydiruomc+eUt0mw==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -8352,6 +8191,15 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
       "integrity": "sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw==",
       "dev": true
+    },
+    "node_modules/babel-plugin-transform-hook-names": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-hook-names/-/babel-plugin-transform-hook-names-1.0.2.tgz",
+      "integrity": "sha512-5gafyjyyBTTdX/tQQ0hRgu4AhNHG/hqWi0ZZmg2xvs2FgRkJXzDNKBZCyoYqgFkovfDrgM8OoKg8karoUvWeCw==",
+      "dev": true,
+      "peerDependencies": {
+        "@babel/core": "^7.12.10"
+      }
     },
     "node_modules/babel-preset-current-node-syntax": {
       "version": "1.0.1",
@@ -12070,6 +11918,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "bin": {
+        "he": "bin/he"
+      }
+    },
     "node_modules/hosted-git-info": {
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
@@ -15486,6 +15343,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/kolorist": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/kolorist/-/kolorist-1.8.0.tgz",
+      "integrity": "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==",
+      "dev": true
+    },
     "node_modules/lazy-universal-dotenv": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/lazy-universal-dotenv/-/lazy-universal-dotenv-4.0.0.tgz",
@@ -16121,6 +15984,75 @@
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/node-html-parser": {
+      "version": "6.1.12",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-6.1.12.tgz",
+      "integrity": "sha512-/bT/Ncmv+fbMGX96XG9g05vFt43m/+SYKIs9oAemQVYyVcZmDAI2Xq/SbNcpOA35eF0Zk2av3Ksf+Xk8Vt8abA==",
+      "dev": true,
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "he": "1.2.0"
+      }
+    },
+    "node_modules/node-html-parser/node_modules/css-select": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+      "dev": true,
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/node-html-parser/node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dev": true,
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/node-html-parser/node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dev": true,
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/node-html-parser/node_modules/domutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "dev": true,
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/node-int64": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@storybook/addon-links": "^8.0.0",
     "@storybook/blocks": "^7.6.6",
     "@storybook/preact": "^8.0.0",
-    "@storybook/preact-vite": "^8.0.0",
+    "@storybook/preact-vite": "^7.6.6",
     "@storybook/test": "^8.0.0",
     "@testing-library/preact": "^3.2.3",
     "babel-jest": "^29.7.0",


### PR DESCRIPTION
We notice an error with Storybook `ReferenceError: React is not defined` , after checking it was because of `storybook/preact-vite` version `8.0.0` as after downgrade it to version `7.6.6`, everything works just fine.

![image](https://github.com/al-mabsut/muslimah/assets/37546491/2a100556-377c-4902-aab1-6508b71ab9c2)
