### PR TITLE
combine all dependabot prs 2024 03 16 7912

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@storybook/addon-essentials": "^7.6.6",
         "@storybook/addon-interactions": "^7.6.6",
         "@storybook/addon-links": "^8.0.0",
-        "@storybook/blocks": "^7.6.6",
+        "@storybook/blocks": "^8.0.0",
         "@storybook/preact": "^8.0.0",
         "@storybook/preact-vite": "^7.6.6",
         "@storybook/test": "^8.0.0",
@@ -4918,6 +4918,64 @@
         "url": "https://opencollective.com/storybook"
       }
     },
+    "node_modules/@storybook/addon-controls/node_modules/@storybook/blocks": {
+      "version": "7.6.17",
+      "resolved": "https://registry.npmjs.org/@storybook/blocks/-/blocks-7.6.17.tgz",
+      "integrity": "sha512-PsNVoe0bX1mMn4Kk3nbKZ0ItDZZ0YJnYAFJ6toAbsyBAbgzg1sce88sQinzvbn58/RT9MPKeWMPB45ZS7ggiNg==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/channels": "7.6.17",
+        "@storybook/client-logger": "7.6.17",
+        "@storybook/components": "7.6.17",
+        "@storybook/core-events": "7.6.17",
+        "@storybook/csf": "^0.1.2",
+        "@storybook/docs-tools": "7.6.17",
+        "@storybook/global": "^5.0.0",
+        "@storybook/manager-api": "7.6.17",
+        "@storybook/preview-api": "7.6.17",
+        "@storybook/theming": "7.6.17",
+        "@storybook/types": "7.6.17",
+        "@types/lodash": "^4.14.167",
+        "color-convert": "^2.0.1",
+        "dequal": "^2.0.2",
+        "lodash": "^4.17.21",
+        "markdown-to-jsx": "^7.1.8",
+        "memoizerific": "^1.11.3",
+        "polished": "^4.2.2",
+        "react-colorful": "^5.1.2",
+        "telejson": "^7.2.0",
+        "tocbot": "^4.20.1",
+        "ts-dedent": "^2.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@storybook/addon-controls/node_modules/@storybook/docs-tools": {
+      "version": "7.6.17",
+      "resolved": "https://registry.npmjs.org/@storybook/docs-tools/-/docs-tools-7.6.17.tgz",
+      "integrity": "sha512-bYrLoj06adqklyLkEwD32C0Ww6t+9ZVvrJHiVT42bIhTRpFiFPAetl1a9KPHtFLnfduh4n2IxIr1jv32ThPDTA==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/core-common": "7.6.17",
+        "@storybook/preview-api": "7.6.17",
+        "@storybook/types": "7.6.17",
+        "@types/doctrine": "^0.0.3",
+        "assert": "^2.1.0",
+        "doctrine": "^3.0.0",
+        "lodash": "^4.17.21"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
     "node_modules/@storybook/addon-docs": {
       "version": "7.6.17",
       "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-7.6.17.tgz",
@@ -4951,6 +5009,64 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@storybook/addon-docs/node_modules/@storybook/blocks": {
+      "version": "7.6.17",
+      "resolved": "https://registry.npmjs.org/@storybook/blocks/-/blocks-7.6.17.tgz",
+      "integrity": "sha512-PsNVoe0bX1mMn4Kk3nbKZ0ItDZZ0YJnYAFJ6toAbsyBAbgzg1sce88sQinzvbn58/RT9MPKeWMPB45ZS7ggiNg==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/channels": "7.6.17",
+        "@storybook/client-logger": "7.6.17",
+        "@storybook/components": "7.6.17",
+        "@storybook/core-events": "7.6.17",
+        "@storybook/csf": "^0.1.2",
+        "@storybook/docs-tools": "7.6.17",
+        "@storybook/global": "^5.0.0",
+        "@storybook/manager-api": "7.6.17",
+        "@storybook/preview-api": "7.6.17",
+        "@storybook/theming": "7.6.17",
+        "@storybook/types": "7.6.17",
+        "@types/lodash": "^4.14.167",
+        "color-convert": "^2.0.1",
+        "dequal": "^2.0.2",
+        "lodash": "^4.17.21",
+        "markdown-to-jsx": "^7.1.8",
+        "memoizerific": "^1.11.3",
+        "polished": "^4.2.2",
+        "react-colorful": "^5.1.2",
+        "telejson": "^7.2.0",
+        "tocbot": "^4.20.1",
+        "ts-dedent": "^2.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@storybook/addon-docs/node_modules/@storybook/docs-tools": {
+      "version": "7.6.17",
+      "resolved": "https://registry.npmjs.org/@storybook/docs-tools/-/docs-tools-7.6.17.tgz",
+      "integrity": "sha512-bYrLoj06adqklyLkEwD32C0Ww6t+9ZVvrJHiVT42bIhTRpFiFPAetl1a9KPHtFLnfduh4n2IxIr1jv32ThPDTA==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/core-common": "7.6.17",
+        "@storybook/preview-api": "7.6.17",
+        "@storybook/types": "7.6.17",
+        "@types/doctrine": "^0.0.3",
+        "assert": "^2.1.0",
+        "doctrine": "^3.0.0",
+        "lodash": "^4.17.21"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
       }
     },
     "node_modules/@storybook/addon-essentials": {
@@ -5088,27 +5204,28 @@
       }
     },
     "node_modules/@storybook/blocks": {
-      "version": "7.6.17",
-      "resolved": "https://registry.npmjs.org/@storybook/blocks/-/blocks-7.6.17.tgz",
-      "integrity": "sha512-PsNVoe0bX1mMn4Kk3nbKZ0ItDZZ0YJnYAFJ6toAbsyBAbgzg1sce88sQinzvbn58/RT9MPKeWMPB45ZS7ggiNg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@storybook/blocks/-/blocks-8.0.0.tgz",
+      "integrity": "sha512-Sxy7pOa6B3ci/XhfKca6u97Kz6pGZV5ieQBUWRYByUZTjiOp12RVLFptexxrJHyNBA00BHJPek4fvFSJfn6nOQ==",
       "dev": true,
       "dependencies": {
-        "@storybook/channels": "7.6.17",
-        "@storybook/client-logger": "7.6.17",
-        "@storybook/components": "7.6.17",
-        "@storybook/core-events": "7.6.17",
+        "@storybook/channels": "8.0.0",
+        "@storybook/client-logger": "8.0.0",
+        "@storybook/components": "8.0.0",
+        "@storybook/core-events": "8.0.0",
         "@storybook/csf": "^0.1.2",
-        "@storybook/docs-tools": "7.6.17",
+        "@storybook/docs-tools": "8.0.0",
         "@storybook/global": "^5.0.0",
-        "@storybook/manager-api": "7.6.17",
-        "@storybook/preview-api": "7.6.17",
-        "@storybook/theming": "7.6.17",
-        "@storybook/types": "7.6.17",
+        "@storybook/icons": "^1.2.5",
+        "@storybook/manager-api": "8.0.0",
+        "@storybook/preview-api": "8.0.0",
+        "@storybook/theming": "8.0.0",
+        "@storybook/types": "8.0.0",
         "@types/lodash": "^4.14.167",
         "color-convert": "^2.0.1",
         "dequal": "^2.0.2",
         "lodash": "^4.17.21",
-        "markdown-to-jsx": "^7.1.8",
+        "markdown-to-jsx": "7.3.2",
         "memoizerific": "^1.11.3",
         "polished": "^4.2.2",
         "react-colorful": "^5.1.2",
@@ -5124,6 +5241,192 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/blocks/node_modules/@storybook/channels": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-8.0.0.tgz",
+      "integrity": "sha512-uykCBlSIMVodsgTFC/XAgO7JeaTJrKtDmmM6Z4liGkPS6EUvurOEu2vK6FuvojzhLHdVJ5bP+VXSJerfm7aE4Q==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "8.0.0",
+        "@storybook/core-events": "8.0.0",
+        "@storybook/global": "^5.0.0",
+        "telejson": "^7.2.0",
+        "tiny-invariant": "^1.3.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/blocks/node_modules/@storybook/client-logger": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-8.0.0.tgz",
+      "integrity": "sha512-olc1vUfaZNkXc7L8UoCdGmyBieHQbsaB+0vVoivYMSa1DHYtXE75RefU3lhMSGrkvIZmXMvfaIDmnyJIOB5FxA==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/global": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/blocks/node_modules/@storybook/components": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@storybook/components/-/components-8.0.0.tgz",
+      "integrity": "sha512-+LmHnR2XQQ76uyWW5u+9ZBlS5sPyJWE6cbMdmkJ0PMGaZdZuF07urcg4z4/qBsDxRZDquBPu/Li5xx6OjXhVKw==",
+      "dev": true,
+      "dependencies": {
+        "@radix-ui/react-slot": "^1.0.2",
+        "@storybook/client-logger": "8.0.0",
+        "@storybook/csf": "^0.1.2",
+        "@storybook/global": "^5.0.0",
+        "@storybook/icons": "^1.2.5",
+        "@storybook/theming": "8.0.0",
+        "@storybook/types": "8.0.0",
+        "memoizerific": "^1.11.3",
+        "util-deprecate": "^1.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@storybook/blocks/node_modules/@storybook/core-events": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-8.0.0.tgz",
+      "integrity": "sha512-kkabj4V99gOTBW+y3HM/LTCDekglqb+lslZMamM+Ytxv1lCqCEOIR/OGfnYOyEaK4BLcx61Zp+fO30FZxtoT1w==",
+      "dev": true,
+      "dependencies": {
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/blocks/node_modules/@storybook/manager-api": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@storybook/manager-api/-/manager-api-8.0.0.tgz",
+      "integrity": "sha512-vJcCc2hG78RjIyhmooqnBlVrTdIomzRqG5WO025tXFgRV1eRUkWJRqSSudcLJO6wk77ZSAtI1ihsDrjsrBFWZw==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/channels": "8.0.0",
+        "@storybook/client-logger": "8.0.0",
+        "@storybook/core-events": "8.0.0",
+        "@storybook/csf": "^0.1.2",
+        "@storybook/global": "^5.0.0",
+        "@storybook/router": "8.0.0",
+        "@storybook/theming": "8.0.0",
+        "@storybook/types": "8.0.0",
+        "dequal": "^2.0.2",
+        "lodash": "^4.17.21",
+        "memoizerific": "^1.11.3",
+        "store2": "^2.14.2",
+        "telejson": "^7.2.0",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/blocks/node_modules/@storybook/preview-api": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@storybook/preview-api/-/preview-api-8.0.0.tgz",
+      "integrity": "sha512-R2NBKtvHi+i1b/3PZe4u4YdJ7dlqr8YTqLn7syB/YSnKRAa7DYed+GJLu4qFJisE6IuYi+57AsdW16otRFEVvg==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/channels": "8.0.0",
+        "@storybook/client-logger": "8.0.0",
+        "@storybook/core-events": "8.0.0",
+        "@storybook/csf": "^0.1.2",
+        "@storybook/global": "^5.0.0",
+        "@storybook/types": "8.0.0",
+        "@types/qs": "^6.9.5",
+        "dequal": "^2.0.2",
+        "lodash": "^4.17.21",
+        "memoizerific": "^1.11.3",
+        "qs": "^6.10.0",
+        "tiny-invariant": "^1.3.1",
+        "ts-dedent": "^2.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/blocks/node_modules/@storybook/router": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@storybook/router/-/router-8.0.0.tgz",
+      "integrity": "sha512-NPV4pb7TBOepPymHBLDmnwPcH4SnrNsD3LiHaVoaE4xaKMZBse2slWxeWM6IGb6Ynoy6pQpsHhAnt+rTjlcv9w==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "8.0.0",
+        "memoizerific": "^1.11.3",
+        "qs": "^6.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/blocks/node_modules/@storybook/theming": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-8.0.0.tgz",
+      "integrity": "sha512-Yu6ybemarPN3RBdsljtvpEVNqnqG1YxDLOmkzl1MFtJ1uA5Zd5mTMjc37iD0WDvLOk8mc1HmEqB5+fDrX0U4Vw==",
+      "dev": true,
+      "dependencies": {
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.0.1",
+        "@storybook/client-logger": "8.0.0",
+        "@storybook/global": "^5.0.0",
+        "memoizerific": "^1.11.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/blocks/node_modules/@storybook/types": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@storybook/types/-/types-8.0.0.tgz",
+      "integrity": "sha512-6nJipdgoAkVFk2JpRPCm9vb/Yuak2lmdZRv9qzl8cNRttlbOESVlzbmhgxCmWV0OYUaMeYge9L8NWhJ14LKbzw==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/channels": "8.0.0",
+        "@types/express": "^4.7.0",
+        "file-system-cache": "2.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
       }
     },
     "node_modules/@storybook/builder-manager": {
@@ -5806,14 +6109,14 @@
       "dev": true
     },
     "node_modules/@storybook/docs-tools": {
-      "version": "7.6.17",
-      "resolved": "https://registry.npmjs.org/@storybook/docs-tools/-/docs-tools-7.6.17.tgz",
-      "integrity": "sha512-bYrLoj06adqklyLkEwD32C0Ww6t+9ZVvrJHiVT42bIhTRpFiFPAetl1a9KPHtFLnfduh4n2IxIr1jv32ThPDTA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@storybook/docs-tools/-/docs-tools-8.0.0.tgz",
+      "integrity": "sha512-d6slxGMosurSTPp1zOTnr7EILnm9xmUrT0xF3Vxr3Yat5/YQEe3WSADktIFyWwlqvIu7MQ8Lh+oelAb5TuxiDw==",
       "dev": true,
       "dependencies": {
-        "@storybook/core-common": "7.6.17",
-        "@storybook/preview-api": "7.6.17",
-        "@storybook/types": "7.6.17",
+        "@storybook/core-common": "8.0.0",
+        "@storybook/preview-api": "8.0.0",
+        "@storybook/types": "8.0.0",
         "@types/doctrine": "^0.0.3",
         "assert": "^2.1.0",
         "doctrine": "^3.0.0",
@@ -5824,11 +6127,310 @@
         "url": "https://opencollective.com/storybook"
       }
     },
+    "node_modules/@storybook/docs-tools/node_modules/@storybook/channels": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-8.0.0.tgz",
+      "integrity": "sha512-uykCBlSIMVodsgTFC/XAgO7JeaTJrKtDmmM6Z4liGkPS6EUvurOEu2vK6FuvojzhLHdVJ5bP+VXSJerfm7aE4Q==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "8.0.0",
+        "@storybook/core-events": "8.0.0",
+        "@storybook/global": "^5.0.0",
+        "telejson": "^7.2.0",
+        "tiny-invariant": "^1.3.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/docs-tools/node_modules/@storybook/client-logger": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-8.0.0.tgz",
+      "integrity": "sha512-olc1vUfaZNkXc7L8UoCdGmyBieHQbsaB+0vVoivYMSa1DHYtXE75RefU3lhMSGrkvIZmXMvfaIDmnyJIOB5FxA==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/global": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/docs-tools/node_modules/@storybook/core-common": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@storybook/core-common/-/core-common-8.0.0.tgz",
+      "integrity": "sha512-fqlQYw5/PDW/oj34QwU5u0HkNLPgELfszsvLFsUcwI7uAzwb/WC2WdPvncT7qRPNcSZLXKJcA8QAqKL4t4I8bg==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/core-events": "8.0.0",
+        "@storybook/csf-tools": "8.0.0",
+        "@storybook/node-logger": "8.0.0",
+        "@storybook/types": "8.0.0",
+        "@yarnpkg/fslib": "2.10.3",
+        "@yarnpkg/libzip": "2.3.0",
+        "chalk": "^4.1.0",
+        "cross-spawn": "^7.0.3",
+        "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0",
+        "esbuild-register": "^3.5.0",
+        "execa": "^5.0.0",
+        "file-system-cache": "2.3.0",
+        "find-cache-dir": "^3.0.0",
+        "find-up": "^5.0.0",
+        "fs-extra": "^11.1.0",
+        "glob": "^10.0.0",
+        "handlebars": "^4.7.7",
+        "lazy-universal-dotenv": "^4.0.0",
+        "node-fetch": "^2.0.0",
+        "picomatch": "^2.3.0",
+        "pkg-dir": "^5.0.0",
+        "pretty-hrtime": "^1.0.3",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.3.7",
+        "tempy": "^1.0.1",
+        "tiny-invariant": "^1.3.1",
+        "ts-dedent": "^2.0.0",
+        "util": "^0.12.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/docs-tools/node_modules/@storybook/core-events": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-8.0.0.tgz",
+      "integrity": "sha512-kkabj4V99gOTBW+y3HM/LTCDekglqb+lslZMamM+Ytxv1lCqCEOIR/OGfnYOyEaK4BLcx61Zp+fO30FZxtoT1w==",
+      "dev": true,
+      "dependencies": {
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/docs-tools/node_modules/@storybook/csf-tools": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-tools/-/csf-tools-8.0.0.tgz",
+      "integrity": "sha512-VIMaZJiGM2NVzlgxaOyaVlH1pw/VSrJygDqOZyANh/kl4KHA+6xIqOkZC+X0+5K295dTFx2nR6S3btTjwT/Wrg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/generator": "^7.23.0",
+        "@babel/parser": "^7.23.0",
+        "@babel/traverse": "^7.23.2",
+        "@babel/types": "^7.23.0",
+        "@storybook/csf": "^0.1.2",
+        "@storybook/types": "8.0.0",
+        "fs-extra": "^11.1.0",
+        "recast": "^0.23.5",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/docs-tools/node_modules/@storybook/node-logger": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-8.0.0.tgz",
+      "integrity": "sha512-C/sMNQqCIYVtJaLpe92RSkPgW3GXcWp6QeH5+glfP42kh+G9axxnEJJ996tyAnNQRzUuI+Eh+B7ytPZU1/WseQ==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/docs-tools/node_modules/@storybook/preview-api": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@storybook/preview-api/-/preview-api-8.0.0.tgz",
+      "integrity": "sha512-R2NBKtvHi+i1b/3PZe4u4YdJ7dlqr8YTqLn7syB/YSnKRAa7DYed+GJLu4qFJisE6IuYi+57AsdW16otRFEVvg==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/channels": "8.0.0",
+        "@storybook/client-logger": "8.0.0",
+        "@storybook/core-events": "8.0.0",
+        "@storybook/csf": "^0.1.2",
+        "@storybook/global": "^5.0.0",
+        "@storybook/types": "8.0.0",
+        "@types/qs": "^6.9.5",
+        "dequal": "^2.0.2",
+        "lodash": "^4.17.21",
+        "memoizerific": "^1.11.3",
+        "qs": "^6.10.0",
+        "tiny-invariant": "^1.3.1",
+        "ts-dedent": "^2.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/docs-tools/node_modules/@storybook/types": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@storybook/types/-/types-8.0.0.tgz",
+      "integrity": "sha512-6nJipdgoAkVFk2JpRPCm9vb/Yuak2lmdZRv9qzl8cNRttlbOESVlzbmhgxCmWV0OYUaMeYge9L8NWhJ14LKbzw==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/channels": "8.0.0",
+        "@types/express": "^4.7.0",
+        "file-system-cache": "2.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/docs-tools/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@storybook/docs-tools/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@storybook/docs-tools/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@storybook/docs-tools/node_modules/glob": {
+      "version": "10.3.10",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
+      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^2.3.5",
+        "minimatch": "^9.0.1",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+        "path-scurry": "^1.10.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@storybook/docs-tools/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@storybook/docs-tools/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@storybook/docs-tools/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@storybook/docs-tools/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@storybook/docs-tools/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@storybook/docs-tools/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
     "node_modules/@storybook/global": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@storybook/global/-/global-5.0.0.tgz",
       "integrity": "sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==",
       "dev": true
+    },
+    "node_modules/@storybook/icons": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/@storybook/icons/-/icons-1.2.9.tgz",
+      "integrity": "sha512-cOmylsz25SYXaJL/gvTk/dl3pyk7yBFRfeXTsHvTA3dfhoU/LWSq0NKL9nM7WBasJyn6XPSGnLS4RtKXLw5EUg==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
     },
     "node_modules/@storybook/instrumenter": {
       "version": "8.0.0",
@@ -15633,9 +16235,9 @@
       "dev": true
     },
     "node_modules/markdown-to-jsx": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.4.3.tgz",
-      "integrity": "sha512-qwu2XftKs/SP+f6oCe0ruAFKX6jZaKxrBfDBV4CthqbVbRQwHhNM28QGDQuTldCaOn+hocaqbmGvCuXO5m3smA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.3.2.tgz",
+      "integrity": "sha512-B+28F5ucp83aQm+OxNrPkS8z0tMKaeHiy0lHJs3LqCyDQFtWuenaIrkaVTgAm1pf1AU85LXltva86hlaT17i8Q==",
       "dev": true,
       "engines": {
         "node": ">= 10"

--- a/package-lock.json
+++ b/package-lock.json
@@ -17424,9 +17424,9 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "6.0.15",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.15.tgz",
-      "integrity": "sha512-rEYkQOMUCEMhsKbK66tbEU9QVIxbhN18YiniAwA7XQYTVBqrBy+P2p5JcdqsHgKM2zWylp8d7J6eszocfds5Sw==",
+      "version": "6.0.16",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.16.tgz",
+      "integrity": "sha512-A0RVJrX+IUkVZbW3ClroRWurercFhieevHB38sr2+l9eUClMqome3LmEmnhlNy+5Mr2EYN6B2Kaw9wYdd+VHiw==",
       "dev": true,
       "dependencies": {
         "cssesc": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6968,9 +6968,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "18.2.65",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.65.tgz",
-      "integrity": "sha512-98TsY0aW4jqx/3RqsUXwMDZSWR1Z4CUlJNue8ueS2/wcxZOsz4xmW1X8ieaWVRHcmmQM3R8xVA4XWB3dJnWwDQ==",
+      "version": "18.2.66",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.66.tgz",
+      "integrity": "sha512-OYTmMI4UigXeFMF/j4uv0lBBEbongSgptPrHBxqME44h9+yNov+oL6Z3ocJKo0WyXR84sQUNeyIp9MRfckvZpg==",
       "dev": true,
       "dependencies": {
         "@types/prop-types": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3780,9 +3780,9 @@
       "dev": true
     },
     "node_modules/@preact/preset-vite": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/@preact/preset-vite/-/preset-vite-2.8.1.tgz",
-      "integrity": "sha512-a9KV4opdj17X2gOFuGup0aE+sXYABX/tJi/QDptOrleX4FlnoZgDWvz45tHOdVfrZX+3uvVsIYPHxRsTerkDNA==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@preact/preset-vite/-/preset-vite-2.8.2.tgz",
+      "integrity": "sha512-m3tl+M8IO8jgiHnk+7LSTFl8axdPXloewi7iGVLdmCwf34XOzEUur0bZVewW4DUbUipFjTS2CXu27+5f/oexBA==",
       "dev": true,
       "dependencies": {
         "@babel/plugin-transform-react-jsx": "^7.22.15",
@@ -3794,7 +3794,9 @@
         "kolorist": "^1.8.0",
         "magic-string": "0.30.5",
         "node-html-parser": "^6.1.10",
-        "resolve": "^1.22.8"
+        "resolve": "^1.22.8",
+        "source-map": "^0.7.4",
+        "stack-trace": "^1.0.0-pre2"
       },
       "peerDependencies": {
         "@babel/core": "7.x",
@@ -3812,6 +3814,15 @@
       },
       "engines": {
         "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/@preact/preset-vite/node_modules/source-map": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/@prefresh/babel-plugin": {
@@ -19016,6 +19027,15 @@
       "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
       "deprecated": "Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility",
       "dev": true
+    },
+    "node_modules/stack-trace": {
+      "version": "1.0.0-pre2",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-1.0.0-pre2.tgz",
+      "integrity": "sha512-2ztBJRek8IVofG9DBJqdy2N5kulaacX30Nz7xmkYF6ale9WBVmIy6mFBchvGX7Vx/MyjBhx+Rcxqrj+dbOnQ6A==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17942,9 +17942,9 @@
       }
     },
     "node_modules/react-remove-scroll-bar": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.5.tgz",
-      "integrity": "sha512-3cqjOqg6s0XbOjWvmasmqHch+RLxIEk2r/70rzGXuz3iIGQsQheEQyqYCBb5EECoD01Vo2SIbDqW4paLeLTASw==",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.6.tgz",
+      "integrity": "sha512-DtSYaao4mBmX+HDo5YWYdBWQwYIQQshUV/dVxFxK+KM26Wjwp1gZ6rv6OC3oujI6Bfu6Xyg3TwK533AQutsn/g==",
       "dev": true,
       "dependencies": {
         "react-style-singleton": "^2.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9873,9 +9873,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.702",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.702.tgz",
-      "integrity": "sha512-LYLXyEUsZ3nNSwiOWjI88N1PJUAMU2QphQSgGLVkFnb3FxZxNui2Vzi2PaKPgPWbsWbZstZnh6BMf/VQJamjiQ==",
+      "version": "1.4.707",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.707.tgz",
+      "integrity": "sha512-qRq74Mo7ChePOU6GHdfAJ0NREXU8vQTlVlfWz3wNygFay6xrd/fY2J7oGHwrhFeU30OVctGLdTh/FcnokTWpng==",
       "dev": true
     },
     "node_modules/emittery": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20768,9 +20768,9 @@
       }
     },
     "node_modules/watchpack": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
-      "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.1.tgz",
+      "integrity": "sha512-8wrBCMtVhqcXP2Sup1ctSkga6uc2Bx0IIvKyT7yTFier5AXHooSI+QyQQAtTb7+E0IUCCKyTFmXqdqgum2XWGg==",
       "dev": true,
       "dependencies": {
         "glob-to-regexp": "^0.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5489,9 +5489,9 @@
       }
     },
     "node_modules/@storybook/core-common/node_modules/@types/node": {
-      "version": "18.19.23",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.23.tgz",
-      "integrity": "sha512-wtE3d0OUfNKtZYAqZb8HAWGxxXsImJcPUAgZNw+dWFxO6s5tIwIjyKnY76tsTatsNCLJPkVYwUpq15D38ng9Aw==",
+      "version": "18.19.24",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.24.tgz",
+      "integrity": "sha512-eghAz3gnbQbvnHqB+mgB2ZR3aH6RhdEmHGS48BnV75KceQPHqabkxKI0BbUSsqhqy2Ddhc2xD/VAR9ySZd57Lw==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -5662,9 +5662,9 @@
       }
     },
     "node_modules/@storybook/core-server/node_modules/@types/node": {
-      "version": "18.19.23",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.23.tgz",
-      "integrity": "sha512-wtE3d0OUfNKtZYAqZb8HAWGxxXsImJcPUAgZNw+dWFxO6s5tIwIjyKnY76tsTatsNCLJPkVYwUpq15D38ng9Aw==",
+      "version": "18.19.24",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.24.tgz",
+      "integrity": "sha512-eghAz3gnbQbvnHqB+mgB2ZR3aH6RhdEmHGS48BnV75KceQPHqabkxKI0BbUSsqhqy2Ddhc2xD/VAR9ySZd57Lw==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -6930,9 +6930,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.11.26",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.26.tgz",
-      "integrity": "sha512-YwOMmyhNnAWijOBQweOJnQPl068Oqd4K3OFbTc6AHJwzweUwwWG3GIFY74OKks2PJUDkQPeddOQES9mLn1CTEQ==",
+      "version": "20.11.28",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.28.tgz",
+      "integrity": "sha512-M/GPWVS2wLkSkNHVeLkrF2fD5Lx5UC4PxA0uZcKc6QqbIQUJyW1jVjueJYi1z8n0I5PxYrtpnPnWglE+y9A0KA==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8288,12 +8288,15 @@
       }
     },
     "node_modules/binary-extensions": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
       "dev": true,
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/bl": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11335,9 +11335,9 @@
       "dev": true
     },
     "node_modules/flow-parser": {
-      "version": "0.230.0",
-      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.230.0.tgz",
-      "integrity": "sha512-ZAfKaarESYYcP/RoLdM91vX0u/1RR7jI5TJaFLnxwRlC2mp0o+Rw7ipIY7J6qpIpQYtAobWb/J6S0XPeu0gO8g==",
+      "version": "0.231.0",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.231.0.tgz",
+      "integrity": "sha512-WVzuqwq7ZnvBceCG0DGeTQebZE+iIU0mlk5PmJgYj9DDrt+0isGC2m1ezW9vxL4V+HERJJo9ExppOnwKH2op6Q==",
       "dev": true,
       "engines": {
         "node": ">=0.4.0"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@storybook/addon-essentials": "^7.6.6",
     "@storybook/addon-interactions": "^7.6.6",
     "@storybook/addon-links": "^8.0.0",
-    "@storybook/blocks": "^7.6.6",
+    "@storybook/blocks": "^8.0.0",
     "@storybook/preact": "^8.0.0",
     "@storybook/preact-vite": "^7.6.6",
     "@storybook/test": "^8.0.0",


### PR DESCRIPTION
- Dependabot: Bump @preact/preset-vite from 2.8.1 to 2.8.2
- Dependabot: Bump binary-extensions from 2.2.0 to 2.3.0
- Dependabot: Bump electron-to-chromium from 1.4.702 to 1.4.707
- Dependabot: Bump @types/react from 18.2.65 to 18.2.66
- Dependabot: Bump @storybook/blocks from 7.6.17 to 8.0.0
- Dependabot: Bump @types/node from 18.19.23 to 18.19.24
- Dependabot: Bump flow-parser from 0.230.0 to 0.231.0
- Dependabot: Bump watchpack from 2.4.0 to 2.4.1
- Dependabot: Bump postcss-selector-parser from 6.0.15 to 6.0.16
- Dependabot: Bump react-remove-scroll-bar from 2.3.5 to 2.3.6
