### PR TITLE
combine all dependabot prs 2024 03 19 3274

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7581,9 +7581,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "18.2.66",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.66.tgz",
-      "integrity": "sha512-OYTmMI4UigXeFMF/j4uv0lBBEbongSgptPrHBxqME44h9+yNov+oL6Z3ocJKo0WyXR84sQUNeyIp9MRfckvZpg==",
+      "version": "18.2.67",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.67.tgz",
+      "integrity": "sha512-vkIE2vTIMHQ/xL0rgmuoECBCkZFZeHr49HeWSc24AptMbNRo7pwSBvj73rlJJs9fGKj0koS+V7kQB1jHS0uCgw==",
       "dev": true,
       "dependencies": {
         "@types/prop-types": "*",


### PR DESCRIPTION
- Dependabot: Bump source-map-js from 1.0.2 to 1.1.0
- Dependabot: Bump reflect.getprototypeof from 1.0.5 to 1.0.6
- Dependabot: Bump es-iterator-helpers from 1.0.17 to 1.0.18
- Dependabot: Bump ufo from 1.4.0 to 1.5.1
- Dependabot: Bump electron-to-chromium from 1.4.707 to 1.4.708
- Dependabot: Bump @types/react from 18.2.66 to 18.2.67
