### PR TITLE
combine all dependabot prs 2024 03 19 2924

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20596,9 +20596,9 @@
       }
     },
     "node_modules/ufo": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.5.1.tgz",
-      "integrity": "sha512-HGyF79+/qZ4soRvM+nHERR2pJ3VXDZ/8sL1uLahdgEDf580NkgiWOxLk33FetExqOWp352JZRsgXbG/4MaGOSg==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.5.2.tgz",
+      "integrity": "sha512-eiutMaL0J2MKdhcOM1tUy13pIrYnyR87fEd8STJQFrrAwImwvlXkxlZEjaKah8r2viPohld08lt73QfLG1NxMg==",
       "dev": true
     },
     "node_modules/uglify-js": {


### PR DESCRIPTION
- Dependabot: Bump electron-to-chromium from 1.4.708 to 1.4.710
- Dependabot: Bump ufo from 1.5.1 to 1.5.2
