### PR TITLE
combine all dependabot prs 2024 03 20 8169

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20627,9 +20627,9 @@
       }
     },
     "node_modules/ufo": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.5.2.tgz",
-      "integrity": "sha512-eiutMaL0J2MKdhcOM1tUy13pIrYnyR87fEd8STJQFrrAwImwvlXkxlZEjaKah8r2viPohld08lt73QfLG1NxMg==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.5.3.tgz",
+      "integrity": "sha512-Y7HYmWaFwPUmkoQCUIAYpKqkOf+SbVj/2fJJZ4RJMCfZp0rTGwRbzQD+HghfnhKOjL9E01okqz+ncJskGYfBNw==",
       "dev": true
     },
     "node_modules/uglify-js": {


### PR DESCRIPTION
- Dependabot: Bump @types/node from 18.19.25 to 18.19.26
- Dependabot: Bump vite from 5.1.6 to 5.2.0
- Dependabot: Bump electron-to-chromium from 1.4.710 to 1.4.711
- Dependabot: Bump preact from 10.19.6 to 10.20.0
- Dependabot: Bump string.prototype.matchall from 4.0.10 to 4.0.11
- Dependabot: Bump @babel/eslint-parser from 7.23.10 to 7.24.1
- Dependabot: Bump @storybook/test from 8.0.1 to 8.0.2
- Dependabot: Bump @storybook/preact from 8.0.1 to 8.0.2
- Dependabot: Bump source-map-js from 1.1.0 to 1.2.0
- Dependabot: Bump magic-string from 0.30.5 to 0.30.8
- Dependabot: Bump @storybook/addon-links from 8.0.1 to 8.0.2
- Dependabot: Bump postcss from 8.4.36 to 8.4.37
- Dependabot: Bump babel-plugin-polyfill-corejs3 from 0.10.1 to 0.10.2
- Dependabot: Bump @babel/highlight from 7.24.1 to 7.24.2
- Dependabot: Bump caniuse-lite from 1.0.30001597 to 1.0.30001599
- Dependabot: Bump preact-render-to-string from 6.4.0 to 6.4.1
- Dependabot: Bump array.prototype.findlast from 1.2.4 to 1.2.5
- Dependabot: Bump @babel/code-frame from 7.24.1 to 7.24.2
- Dependabot: Bump @babel/runtime from 7.24.0 to 7.24.1
- Dependabot: Bump @babel/core from 7.24.0 to 7.24.1
- Dependabot: Bump aria-hidden from 1.2.3 to 1.2.4
- Dependabot: Bump @storybook/blocks from 8.0.1 to 8.0.2
- Dependabot: Bump ufo from 1.5.2 to 1.5.3
