### PR TITLE
combine all dependabot prs 2024 03 25 9385

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7527,9 +7527,9 @@
       "dev": true
     },
     "node_modules/@types/mdx": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.11.tgz",
-      "integrity": "sha512-HM5bwOaIQJIQbAYfax35HCKxx7a3KrK3nBtIqJgSOitivTD1y3oW9P3rxY9RkXYPUk7y/AjAohfHKmFpGE79zw==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.12.tgz",
+      "integrity": "sha512-H9VZ9YqE+H28FQVchC83RCs5xQ2J7mAAv6qdDEaWmXEVl3OpdH+xfrSUzQ1lp7U7oSTRZ0RvW08ASPJsYBi7Cw==",
       "dev": true
     },
     "node_modules/@types/mime": {


### PR DESCRIPTION
- Dependabot: Bump preact from 10.20.0 to 10.20.1
- Dependabot: Bump @types/prop-types from 15.7.11 to 15.7.12
- Dependabot: Bump cli-table3 from 0.6.3 to 0.6.4
- Dependabot: Bump vite from 5.2.4 to 5.2.6
- Dependabot: Bump object.hasown from 1.1.3 to 1.1.4
- Dependabot: Bump @types/mdx from 2.0.11 to 2.0.12
