### PR TITLE
combine all dependabot prs 2024 03 28 8192

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10528,9 +10528,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.715",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.715.tgz",
-      "integrity": "sha512-XzWNH4ZSa9BwVUQSDorPWAUQ5WGuYz7zJUNpNif40zFCiCl20t8zgylmreNmn26h5kiyw2lg7RfTmeMBsDklqg==",
+      "version": "1.4.717",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.717.tgz",
+      "integrity": "sha512-6Fmg8QkkumNOwuZ/5mIbMU9WI3H2fmn5ajcVya64I5Yr5CcNmO7vcLt0Y7c96DCiMO5/9G+4sI2r6eEvdg1F7A==",
       "dev": true
     },
     "node_modules/emittery": {


### PR DESCRIPTION
- Dependabot: Bump express from 4.19.1 to 4.19.2
- Dependabot: Bump @types/scheduler from 0.16.8 to 0.23.0
- Dependabot: Bump @types/react from 18.2.67 to 18.2.71
- Dependabot: Bump electron-to-chromium from 1.4.715 to 1.4.717
