### PR TITLE
combine all dependabot prs 2024 04 02 1500

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9199,9 +9199,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001603",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001603.tgz",
-      "integrity": "sha512-iL2iSS0eDILMb9n5yKQoTBim9jMZ0Yrk8g0N9K7UzYyWnfIKzXBZD5ngpM37ZcL/cv0Mli8XtVMRYMQAfFpi5Q==",
+      "version": "1.0.30001605",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001605.tgz",
+      "integrity": "sha512-nXwGlFWo34uliI9z3n6Qc0wZaf7zaZWA1CPZ169La5mV3I/gem7bst0vr5XQH5TJXZIMfDeZyOrZnSlVzKxxHQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
- Dependabot: Bump electron-to-chromium from 1.4.722 to 1.4.723
- Dependabot: Bump @humanwhocodes/object-schema from 2.0.2 to 2.0.3
- Dependabot: Bump caniuse-lite from 1.0.30001603 to 1.0.30001605
