### PR TITLE
0.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@al-mabsut/muslimah",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@al-mabsut/muslimah",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "ISC",
       "devDependencies": {
         "@babel/core": "^7.23.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al-mabsut/muslimah",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Shari' ahkaam related to muslim women matters",
   "main": "dist/cjs/bundle.js",
   "module": "dist/esm/bundle.js",


### PR DESCRIPTION
In this relase we have introduced :

Allow links to be clickable
* Remove extra empty tags around links
* Allow links to be clicked and to open in a new tab.

Fix unclickable terminologies
* Some terminologies were not rendered as expected, because there was an extra `‘` before them in `‘Asr` and `‘Isha` so we simply append it to rectify the issue.
* Fix storybook error when changing the scenarios ( previously it was require a refresh ) because of the style checking we made to prevent extra `.` for lists