### PR TITLE
Introduce basic levels settings

### DIFF
--- a/jest.config.cjs.js
+++ b/jest.config.cjs.js
@@ -3,6 +3,7 @@ import commonConfig from './jest.config.common.js';
 export default {
   ...commonConfig,
   moduleNameMapper: {
+    ...commonConfig.moduleNameMapper,
     '^@al-mabsut/muslimah$': '<rootDir>/dist/cjs/bundle.js'
   }
 };

--- a/jest.config.esm.js
+++ b/jest.config.esm.js
@@ -3,6 +3,7 @@ import commonConfig from './jest.config.common.js';
 export default {
   ...commonConfig,
   moduleNameMapper: {
+    ...commonConfig.moduleNameMapper,
     '^@al-mabsut/muslimah$': '<rootDir>/dist/esm/bundle.js'
   }
 };

--- a/src/components/Content/index.js
+++ b/src/components/Content/index.js
@@ -1,8 +1,15 @@
 /* eslint-disable react/jsx-no-bind */
 import terminologies from './terminologies.json';
 import { Fragment } from 'preact';
+import { LEVELS } from '@utils/constants';
 
-export const prepareClickableWords = ({ text, action }) => {
+const shouldDisplayExplanation = ({ userLevel, wordLevel }) => {
+  const userLevelIndex = LEVELS.indexOf(userLevel);
+  const wordLevelIndex = LEVELS.indexOf(wordLevel);
+  return userLevelIndex < wordLevelIndex;
+};
+
+export const prepareClickableWords = ({ text, settings, action }) => {
   const words = text.split(' ');
   const regexCharsToRemove = /[:.,()]/g;
 
@@ -10,7 +17,7 @@ export const prepareClickableWords = ({ text, action }) => {
     const isClickable = terminologies[word.toLowerCase().replaceAll(regexCharsToRemove, '')]?.clarification?.en || false;
     const specialChars = isClickable ? word.match(regexCharsToRemove) : null;
     const specialCharPosition = (specialChars && specialChars[0]) ? word.indexOf(specialChars[0]) : null;
-    const wordWithPostfix = isClickable ? `${word.replaceAll(regexCharsToRemove, '')} (${isClickable}) ` : word;
+    const wordWithPostfix = isClickable ? `${word.replaceAll(regexCharsToRemove, '')} ${ shouldDisplayExplanation({ userLevel: settings.level, wordLevel: terminologies[word.toLowerCase().replaceAll(regexCharsToRemove, '')].level }) ? `(${isClickable})` : ''} ` : word;
 
     if ( word.includes('http') ) {
       // eslint-disable-next-line react/jsx-no-target-blank
@@ -42,7 +49,7 @@ const arrayToHtml = (arr) => {
   return mainHtml;
 };
 
-export const prepareTextElements = ({ text, title, action }) => {
+export const prepareTextElements = ({ text, title, settings, action }) => {
   const elements = [];
   const currentDepths = [];
   const depthIndexMap = {};
@@ -52,7 +59,7 @@ export const prepareTextElements = ({ text, title, action }) => {
     const t = text[i];
     const depth = (t.match(/in:/g) || []).length;
 
-    const nestedItem = <li key={`prepare_text_${title}_nested_${i}`}>{prepareClickableWords({ text: t.replaceAll('in:', ''), action })}</li>;
+    const nestedItem = <li key={`prepare_text_${title}_nested_${i}`}>{prepareClickableWords({ text: t.replaceAll('in:', ''), settings, action })}</li>;
 
     if ( depth < prevDepth ) {
       currentDepths.splice(currentDepths.indexOf(prevDepth), 1);
@@ -81,10 +88,10 @@ export const prepareTextElements = ({ text, title, action }) => {
   return (arrayToHtml(elements));
 };
 
-const Content = ({ heading, text, action, showInnerTitle }) => (
+const Content = ({ heading, text, action, showInnerTitle, settings }) => (
   <div>
     { showInnerTitle && <h3>{heading}</h3>}
-    { text && prepareTextElements({ text, title: heading, action: ({ word }) => {
+    { text && prepareTextElements({ text, title: heading, settings, action: ({ word }) => {
       if ( action ) {
         action({ word });
       }
@@ -98,10 +105,10 @@ const Content = ({ heading, text, action, showInnerTitle }) => (
 
 export const Title = ({ text }) => <h2>{text}</h2>;
 
-export const Guidance = ({ text, action, showIcons, showInnerTitle }) => <Content action={action} heading="Guidance" text={text} showIcons={showIcons} showInnerTitle={showInnerTitle} />;
+export const Guidance = ({ text, action, showIcons, showInnerTitle, settings }) => <Content action={action} heading="Guidance" text={text} showIcons={showIcons} showInnerTitle={showInnerTitle} settings={settings} />;
 
-export const Clarification = ({ text, action, showIcons, showInnerTitle }) => <Content action={action} heading="Clarification" text={text} showIcons={showIcons} showInnerTitle={showInnerTitle} />;
+export const Clarification = ({ text, action, showIcons, showInnerTitle, settings }) => <Content action={action} heading="Clarification" text={text} showIcons={showIcons} showInnerTitle={showInnerTitle} settings={settings} />;
 
-export const Ramadan = ({ text, action, showIcons, showInnerTitle }) => <Content action={action} heading="Ramadan" text={text} showIcons={showIcons} showInnerTitle={showInnerTitle} />;
+export const Ramadan = ({ text, action, showIcons, showInnerTitle, settings }) => <Content action={action} heading="Ramadan" text={text} showIcons={showIcons} showInnerTitle={showInnerTitle} settings={settings} />;
 
-export const Marriage = ({ text, action, showIcons, showInnerTitle }) => <Content action={action} heading="Marriage" text={text} showIcons={showIcons} showInnerTitle={showInnerTitle} />;
+export const Marriage = ({ text, action, showIcons, showInnerTitle, settings }) => <Content action={action} heading="Marriage" text={text} showIcons={showIcons} showInnerTitle={showInnerTitle} settings={settings} />;

--- a/src/components/Hanafiyyah/en/Hayd/index.stories.js
+++ b/src/components/Hanafiyyah/en/Hayd/index.stories.js
@@ -23,6 +23,9 @@ Default.args = {
   className: 'testClassName',
   tabsContainerClassName: 'testTabsContainerClassName',
   tabClassName: 'testTabClassName',
+  popUpClassName: 'testPopUpClassName',
+  settingsClassName: 'testSettingsClassName',
+  settingsModalClassName: 'testSettingsModalClassName',
   showTitle: true,
   showTabsTitle: true,
   showTabsIcons: true,
@@ -30,7 +33,8 @@ Default.args = {
   guidanceIcon: <img width="25px" height="25px" src="https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png" />,
   clarificationIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png',
   ramadanIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png',
-  marriageIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png'
+  marriageIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png',
+  settingsIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/tools-equipment-construction/setting-icon.png'
 };
 
 export const overrideAction = Template.bind({});

--- a/src/components/Hanafiyyah/en/Indeterminate/index.stories.js
+++ b/src/components/Hanafiyyah/en/Indeterminate/index.stories.js
@@ -30,6 +30,9 @@ Default.args = {
   className: 'testClassName',
   tabsContainerClassName: 'testTabsContainerClassName',
   tabClassName: 'testTabClassName',
+  popUpClassName: 'testPopUpClassName',
+  settingsClassName: 'testSettingsClassName',
+  settingsModalClassName: 'testSettingsModalClassName',
   showTitle: true,
   showTabsTitle: true,
   showTabsIcons: true,
@@ -37,7 +40,8 @@ Default.args = {
   guidanceIcon: <img width="25px" height="25px" src="https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png" />,
   clarificationIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png',
   ramadanIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png',
-  marriageIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png'
+  marriageIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png',
+  settingsIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/tools-equipment-construction/setting-icon.png'
 };
 
 export const overrideAction = Template.bind({});

--- a/src/components/Hanafiyyah/en/Istihadah/index.stories.js
+++ b/src/components/Hanafiyyah/en/Istihadah/index.stories.js
@@ -23,6 +23,9 @@ Default.args = {
   className: 'testClassName',
   tabsContainerClassName: 'testTabsContainerClassName',
   tabClassName: 'testTabClassName',
+  popUpClassName: 'testPopUpClassName',
+  settingsClassName: 'testSettingsClassName',
+  settingsModalClassName: 'testSettingsModalClassName',
   showTitle: true,
   showTabsTitle: true,
   showTabsIcons: true,
@@ -30,7 +33,8 @@ Default.args = {
   guidanceIcon: <img width="25px" height="25px" src="https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png" />,
   clarificationIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png',
   ramadanIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png',
-  marriageIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png'
+  marriageIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png',
+  settingsIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/tools-equipment-construction/setting-icon.png'
 };
 
 export const overrideAction = Template.bind({});

--- a/src/components/Hanafiyyah/en/MostLikelyHayd/index.stories.js
+++ b/src/components/Hanafiyyah/en/MostLikelyHayd/index.stories.js
@@ -23,6 +23,9 @@ Default.args = {
   className: 'testClassName',
   tabsContainerClassName: 'testTabsContainerClassName',
   tabClassName: 'testTabClassName',
+  popUpClassName: 'testPopUpClassName',
+  settingsClassName: 'testSettingsClassName',
+  settingsModalClassName: 'testSettingsModalClassName',
   showTitle: true,
   showTabsTitle: true,
   showTabsIcons: true,
@@ -30,7 +33,8 @@ Default.args = {
   guidanceIcon: <img width="25px" height="25px" src="https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png" />,
   clarificationIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png',
   ramadanIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png',
-  marriageIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png'
+  marriageIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png',
+  settingsIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/tools-equipment-construction/setting-icon.png'
 };
 
 export const overrideAction = Template.bind({});

--- a/src/components/Hanafiyyah/en/MostLikelyIstihadah/index.stories.js
+++ b/src/components/Hanafiyyah/en/MostLikelyIstihadah/index.stories.js
@@ -23,6 +23,9 @@ Default.args = {
   className: 'testClassName',
   tabsContainerClassName: 'testTabsContainerClassName',
   tabClassName: 'testTabClassName',
+  popUpClassName: 'testPopUpClassName',
+  settingsClassName: 'testSettingsClassName',
+  settingsModalClassName: 'testSettingsModalClassName',
   showTitle: true,
   showTabsTitle: true,
   showTabsIcons: true,
@@ -30,7 +33,8 @@ Default.args = {
   guidanceIcon: <img width="25px" height="25px" src="https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png" />,
   clarificationIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png',
   ramadanIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png',
-  marriageIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png'
+  marriageIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png',
+  settingsIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/tools-equipment-construction/setting-icon.png'
 };
 
 export const overrideAction = Template.bind({});

--- a/src/components/Hanafiyyah/en/MostLikelyTuhr/index.stories.js
+++ b/src/components/Hanafiyyah/en/MostLikelyTuhr/index.stories.js
@@ -30,6 +30,9 @@ Default.args = {
   className: 'testClassName',
   tabsContainerClassName: 'testTabsContainerClassName',
   tabClassName: 'testTabClassName',
+  popUpClassName: 'testPopUpClassName',
+  settingsClassName: 'testSettingsClassName',
+  settingsModalClassName: 'testSettingsModalClassName',
   showTitle: true,
   showTabsTitle: true,
   showTabsIcons: true,
@@ -37,7 +40,8 @@ Default.args = {
   guidanceIcon: <img width="25px" height="25px" src="https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png" />,
   clarificationIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png',
   ramadanIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png',
-  marriageIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png'
+  marriageIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png',
+  settingsIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/tools-equipment-construction/setting-icon.png'
 };
 
 export const overrideAction = Template.bind({});

--- a/src/components/Hanafiyyah/en/OngoingHayd/index.stories.js
+++ b/src/components/Hanafiyyah/en/OngoingHayd/index.stories.js
@@ -30,6 +30,9 @@ Default.args = {
   className: 'testClassName',
   tabsContainerClassName: 'testTabsContainerClassName',
   tabClassName: 'testTabClassName',
+  popUpClassName: 'testPopUpClassName',
+  settingsClassName: 'testSettingsClassName',
+  settingsModalClassName: 'testSettingsModalClassName',
   showTitle: true,
   showTabsTitle: true,
   showTabsIcons: true,
@@ -37,7 +40,8 @@ Default.args = {
   guidanceIcon: <img width="25px" height="25px" src="https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png" />,
   clarificationIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png',
   ramadanIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png',
-  marriageIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png'
+  marriageIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png',
+  settingsIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/tools-equipment-construction/setting-icon.png'
 };
 
 export const overrideAction = Template.bind({});

--- a/src/components/Hanafiyyah/en/Tuhr/index.stories.js
+++ b/src/components/Hanafiyyah/en/Tuhr/index.stories.js
@@ -30,6 +30,9 @@ Default.args = {
   className: 'testClassName',
   tabsContainerClassName: 'testTabsContainerClassName',
   tabClassName: 'testTabClassName',
+  popUpClassName: 'testPopUpClassName',
+  settingsClassName: 'testSettingsClassName',
+  settingsModalClassName: 'testSettingsModalClassName',
   showTitle: true,
   showTabsTitle: true,
   showTabsIcons: true,
@@ -37,7 +40,8 @@ Default.args = {
   guidanceIcon: <img width="25px" height="25px" src="https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png" />,
   clarificationIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png',
   ramadanIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png',
-  marriageIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png'
+  marriageIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/web-app-development/asterisk-icon.png',
+  settingsIcon: 'https://uxwing.com/wp-content/themes/uxwing/download/tools-equipment-construction/setting-icon.png'
 };
 
 export const overrideAction = Template.bind({});

--- a/src/components/Hidayah/index.js
+++ b/src/components/Hidayah/index.js
@@ -1,9 +1,11 @@
+/* eslint-disable max-len */
 /* eslint-disable react/jsx-no-bind */
 import { Title, Clarification, Guidance, Marriage, Ramadan } from '@components/Content';
 import { useMemo, useState } from 'preact/hooks';
 import PropTypes from 'prop-types';
 import terminologies from '@components/Content/terminologies.json';
 import { Fragment } from 'preact';
+import { LEVELS } from '@utils/constants';
 
 const PopUpModal = ({ popUpClassName, displayPopUpModal, setDisplayPopUpModal, popUpModalWord }) => {
   if ( !displayPopUpModal ) {
@@ -17,12 +19,50 @@ const PopUpModal = ({ popUpClassName, displayPopUpModal, setDisplayPopUpModal, p
   </div>);
 };
 
+const Levels = ({ level, setLevel }) => (<div>
+  { LEVELS && LEVELS.map((lvl) => (
+    <>
+      <input type="radio" id={lvl} name={lvl} value={lvl} checked={lvl === level} onChange={() => setLevel(lvl)} />
+      <label key={lvl} for={lvl}>{lvl}</label>
+    </>
+  ))}
+</div>);
+
+const SettingsModal = ({ settings, setSettings, hideModal, settingsModalClassName }) => (<div style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%', padding: '1%', backgroundColor: '#ddd' }} className={settingsModalClassName || ''}>
+  <button style={{ position: 'absolute', top: '1%', right: '1%', zIndex: 1 }} onClick={hideModal}>X</button>
+  <h3>Settings</h3>
+  <h4>Levels:</h4>
+  <Levels level={settings.level} setLevel={(newLevel) => setSettings((old) => {
+    old.level = newLevel;
+    return { ...old };
+  })}
+  />
+</div>);
+
+const Settings = ({ settings, setSettings, settingsClassName, settingsModalClassName, settingsIcon }) => {
+  const [displaySettingsModal, setDisplaySettingsModal] = useState();
+
+  return (
+    <div className={settingsClassName || ''}>
+      <button style={{ position: 'absolute', top: '20px', right: '20px' }} onClick={() => setDisplaySettingsModal((old) => !old)}>
+        { typeof(settingsIcon) === 'string' ?
+          <img width="25px" height="25px" src={settingsIcon} alt={`settings_icon`} /> :
+          settingsIcon }
+      </button>
+      { displaySettingsModal && <SettingsModal settings={settings} setSettings={setSettings} hideModal={() => setDisplaySettingsModal(false)} settingsModalClassName={settingsModalClassName} /> }
+    </div>
+  );
+};
+
 const Hidayah = ({ content, action, style, className, tabsContainerClassName, tabClassName, contentClassName,
-  popUpClassName, showTabsIcons=true, showTabsTitle=true, showTitle=true, showInnerTitle=true,
-  guidanceIcon, clarificationIcon, ramadanIcon, marriageIcon } = {}) => {
+  popUpClassName, settingsClassName, settingsModalClassName, showTabsIcons=true, showTabsTitle=true, showTitle=true, showInnerTitle=true,
+  guidanceIcon, clarificationIcon, ramadanIcon, marriageIcon, settingsIcon } = {}) => {
   const [activeTab, setActiveTab] = useState('Guidance');
   const [displayPopUpModal, setDisplayPopUpModal] = useState();
   const [popUpModalWord, setPopUpModalTerm] = useState();
+  const [settings, setSettings] = useState({
+    level: 'newcomer'
+  });
   const tabs = useMemo(() => (['Guidance', 'Clarification', 'Ramadan', 'Marriage']), []);
 
   const getIcon = ({ tab }) => {
@@ -49,6 +89,7 @@ const Hidayah = ({ content, action, style, className, tabsContainerClassName, ta
 
   return (
     <div className={className || ''} style={{ ...style }}>
+      <Settings settings={settings} setSettings={setSettings} settingsClassName={settingsClassName} settingsModalClassName={settingsModalClassName} settingsIcon={settingsIcon} />
       { showTitle && <Title text={content.title} />}
       <div className={tabsContainerClassName || ''}>
         {tabs && tabs.map((tab) => (
@@ -65,10 +106,10 @@ const Hidayah = ({ content, action, style, className, tabsContainerClassName, ta
       {/* eslint-disable-next-line max-len */}
       <PopUpModal popUpClassName={popUpClassName} displayPopUpModal={displayPopUpModal} popUpModalWord={popUpModalWord} setDisplayPopUpModal={setDisplayPopUpModal} />
       <div className={contentClassName || ''}>
-        {activeTab === 'Guidance' && <Guidance action={action ? action : alternativeAction} text={content.guidance} showInnerTitle={showInnerTitle} />}
-        {activeTab === 'Clarification' && <Clarification action={action ? action : alternativeAction} text={content.additionalClarifications} showInnerTitle={showInnerTitle} />}
-        {activeTab === 'Ramadan' && <Ramadan action={action ? action : alternativeAction} text={content.ramadanClarifications} showInnerTitle={showInnerTitle} />}
-        {activeTab === 'Marriage' && <Marriage action={action ? action : alternativeAction} text={content.maritalClarifications} showInnerTitle={showInnerTitle} />}
+        {activeTab === 'Guidance' && <Guidance action={action ? action : alternativeAction} text={content.guidance} showInnerTitle={showInnerTitle} settings={settings} />}
+        {activeTab === 'Clarification' && <Clarification action={action ? action : alternativeAction} text={content.additionalClarifications} showInnerTitle={showInnerTitle} settings={settings} />}
+        {activeTab === 'Ramadan' && <Ramadan action={action ? action : alternativeAction} text={content.ramadanClarifications} showInnerTitle={showInnerTitle} settings={settings} />}
+        {activeTab === 'Marriage' && <Marriage action={action ? action : alternativeAction} text={content.maritalClarifications} showInnerTitle={showInnerTitle} settings={settings} />}
       </div>
     </div>
   );
@@ -81,6 +122,9 @@ Hidayah.propTypes = {
   className: PropTypes.string,
   tabClassName: PropTypes.string,
   contentClassName: PropTypes.string,
+  popUpClassName: PropTypes.string,
+  settingsClassName: PropTypes.string,
+  settingsModalClassName: PropTypes.string,
   showTitle: PropTypes.bool,
   showTabsTitle: PropTypes.bool,
   showTabsIcons: PropTypes.bool,
@@ -98,6 +142,10 @@ Hidayah.propTypes = {
     PropTypes.element
   ]),
   marriageIcon: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.element
+  ]),
+  settingsIcon: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.element
   ])

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,0 +1,6 @@
+export const LEVELS = [
+  'newcomer',
+  'basic',
+  'advanced',
+  'expert'
+];


### PR DESCRIPTION
* A settings button where a user can configure how they want terminologies to be rendered, for now we have introduced one item levels
* Level represents the minimal level required to have a reasonable expectation that such a person is familiar with the word and its implications, So the word `'Asr` ( which has `basic` level ) only needs to be clarified for a `newcomer` whereas from `basic` onward it does not need clarification
* In total there are 4 levels: `newcomer` `basic` `advanced` `expert`
* Fix jest import routes
* Add missing `popUpClassName` to Storybook and to the props.