### PR TITLE
combine all dependabot prs 2024 04 04 8353

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -217,9 +217,9 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.24.1.tgz",
-      "integrity": "sha512-1yJa9dX9g//V6fDebXoEfEsxkZHk3Hcbm+zLhyu6qVgYFLvmTALTeV+jNU9e5RnYtioBrGEOdoI2joMSNQ/+aA==",
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.24.4.tgz",
+      "integrity": "sha512-lG75yeuUSVu0pIcbhiYMXBXANHrpUPaOfu7ryAzskCgKUHuAxRQI5ssrtmF0X9UXldPlvT0XM/A4F44OXRt6iQ==",
       "dev": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.22.5",
@@ -1681,13 +1681,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-typescript": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.24.1.tgz",
-      "integrity": "sha512-liYSESjX2fZ7JyBFkYG78nfvHlMKE6IpNdTVnxmlYUR+j5ZLsitFbaAE+eJSK2zPPkNWNw4mXL51rQ8WrvdK0w==",
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.24.4.tgz",
+      "integrity": "sha512-79t3CQ8+oBGk/80SQ8MN3Bs3obf83zJ0YZjDmDaEZN8MqhMI760apl5z6a20kFeMXBwJX99VpKT8CKxEBp5H1g==",
       "dev": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.22.5",
-        "@babel/helper-create-class-features-plugin": "^7.24.1",
+        "@babel/helper-create-class-features-plugin": "^7.24.4",
         "@babel/helper-plugin-utils": "^7.24.0",
         "@babel/plugin-syntax-typescript": "^7.24.1"
       },


### PR DESCRIPTION
- Dependabot: Bump postcss-modules-scope from 3.1.2 to 3.2.0
- Dependabot: Bump postcss-modules-extract-imports from 3.0.0 to 3.1.0
- Dependabot: Bump @babel/plugin-transform-class-static-block
- Dependabot: Bump @babel/generator from 7.24.1 to 7.24.4
- Dependabot: Bump electron-to-chromium from 1.4.724 to 1.4.726
- Dependabot: Bump @babel/compat-data from 7.24.1 to 7.24.4
- Dependabot: Bump flow-parser from 0.232.0 to 0.233.0
- Dependabot: Bump @babel/plugin-transform-block-scoping
- Dependabot: Bump @babel/helper-create-class-features-plugin
- Dependabot: Bump @babel/parser from 7.24.1 to 7.24.4
- Dependabot: Bump @babel/runtime from 7.24.1 to 7.24.4
- Dependabot: Bump @babel/preset-env from 7.24.3 to 7.24.4
- Dependabot: Bump @babel/helpers from 7.24.1 to 7.24.4
- Dependabot: Bump vite from 5.2.7 to 5.2.8
- Dependabot: Bump @babel/core from 7.24.3 to 7.24.4
- Dependabot: Bump @babel/plugin-transform-typescript
