### PR TITLE
combine all dependabot prs 2024 04 08 2285

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9216,9 +9216,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001605",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001605.tgz",
-      "integrity": "sha512-nXwGlFWo34uliI9z3n6Qc0wZaf7zaZWA1CPZ169La5mV3I/gem7bst0vr5XQH5TJXZIMfDeZyOrZnSlVzKxxHQ==",
+      "version": "1.0.30001606",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001606.tgz",
+      "integrity": "sha512-LPbwnW4vfpJId225pwjZJOgX1m9sGfbw/RKJvw/t0QhYOOaTXHvkjVGFGPpvwEzufrjvTlsULnVTxdy4/6cqkg==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
- Dependabot: Bump electron-to-chromium from 1.4.726 to 1.4.728
- Dependabot: Bump typescript from 5.4.3 to 5.4.4
- Dependabot: Bump @types/express-serve-static-core from 4.17.43 to 4.19.0
- Dependabot: Bump caniuse-lite from 1.0.30001605 to 1.0.30001606
