### PR TITLE
combine all dependabot prs 2024 04 17 2175

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10587,9 +10587,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.737",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.737.tgz",
-      "integrity": "sha512-QvLTxaLHKdy5YxvixAw/FfHq2eWLUL9KvsPjp0aHK1gI5d3EDuDgITkvj0nFO2c6zUY3ZqVAJQiBYyQP9tQpfw==",
+      "version": "1.4.738",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.738.tgz",
+      "integrity": "sha512-lwKft2CLFztD+vEIpesrOtCrko/TFnEJlHFdRhazU7Y/jx5qc4cqsocfVrBg4So4gGe9lvxnbLIoev47WMpg+A==",
       "dev": true
     },
     "node_modules/emittery": {


### PR DESCRIPTION
- Dependabot: Bump core-js from 3.36.1 to 3.37.0
- Dependabot: Bump core-js-compat from 3.36.1 to 3.37.0
- Dependabot: Bump electron-to-chromium from 1.4.737 to 1.4.738
