### PR TITLE
Store settings in localStorage

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -53,6 +53,7 @@ const config = {
       alias: [
         { find: '@hanafi', replacement: path.resolve(__dirname, '../contents/hanafi/') },
         { find: '@components', replacement: path.resolve(__dirname, '../src/components/') },
+        { find: '@hooks', replacement: path.resolve(__dirname, '../src/hooks/') },
         { find: '@utils', replacement: path.resolve(__dirname, '../src/utils/') },
         { find: '@src', replacement: path.resolve(__dirname, '../src/') },
         { find: '@al-mabsut/muslimah', replacement: path.resolve(__dirname, '../node_modules/@al-mabsut/muslimah/dist/esm/bundle.js') }

--- a/jest.config.common.js
+++ b/jest.config.common.js
@@ -85,6 +85,7 @@ const commonConfig = {
     '@src(.*)$': '<rootDir>/src/$1',
     '@assets(.*)$': '<rootDir>/src/assets/$1',
     '@components(.*)$': '<rootDir>/src/components/$1',
+    '@hooks(.*)$': '<rootDir>/src/hooks/$1',
     '@utils(.*)$': '<rootDir>/src/utils/$1'
   },
 

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -22,6 +22,7 @@ export default {
       entries: [
         { find: '@hanafi', replacement: path.resolve(__dirname, 'contents/hanafi/') },
         { find: '@components', replacement: path.resolve(__dirname, 'src/components/') },
+        { find: '@hooks', replacement: path.resolve(__dirname, 'src/hooks/') },
         { find: '@utils', replacement: path.resolve(__dirname, 'src/utils/') },
         { find: '@src', replacement: path.resolve(__dirname, 'src/') },
       ]

--- a/src/hooks/useLocalStorage.js
+++ b/src/hooks/useLocalStorage.js
@@ -1,0 +1,30 @@
+import { useState } from 'preact/hooks';
+
+const useLocalStorage = (key, initialValue) => {
+  const [storedValue, setStoredValue] = useState(() => {
+    try {
+      const item = localStorage.getItem(key);
+      return item ? JSON.parse(item) : initialValue;
+    }
+    catch (error) {
+      console.error('Error retrieving state from localStorage:', error);
+      return initialValue;
+    }
+  });
+
+  const setValue = (value) => {
+    try {
+      // Allow value to be a function to support updating state based on previous value
+      const valueToStore = value instanceof Function ? value(storedValue) : value;
+      setStoredValue(valueToStore);
+      localStorage.setItem(key, JSON.stringify(valueToStore));
+    }
+    catch (error) {
+      console.error('Error setting state in localStorage:', error);
+    }
+  };
+
+  return [storedValue, setValue];
+};
+
+export default useLocalStorage;

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -4,3 +4,7 @@ export const LEVELS = [
   'advanced',
   'expert'
 ];
+
+export const DEFAULT_SETTINGS = {
+  level: LEVELS[0]
+};


### PR DESCRIPTION
* Introduce a robust mechanism for storing user settings utilizing localStorage.
* Using a new localStorage key `muslimah_settings` which will contain all Muslimah settings for all users.
* This key serves as a repository for all Muslimah settings, where each user's configuration is stored under their respective userId.
* Clients can now seamlessly retrieve and persist user configurations by passing in the userId. The system intelligently fetches or saves the appropriate settings for the specified user, ensuring accurate and personalized experiences.
* Hide the `userId` arg controller in Storybook due to a bug in Storybook.