### PR TITLE
Introduce ordering to settings

### DIFF
--- a/src/components/Content/index.js
+++ b/src/components/Content/index.js
@@ -1,8 +1,11 @@
+/* eslint-disable max-len */
 /* eslint-disable react/jsx-no-bind */
 import terminologies from './terminologies.json';
 import { Fragment } from 'preact';
-import { LEVELS } from '@utils/constants';
+import { LEVELS, ORDERS } from '@utils/constants';
 import style from './style.module.css';
+
+const regexCharsToRemove = /[:.,()]/g;
 
 const shouldDisplayExplanation = ({ userLevel, wordLevel }) => {
   const userLevelIndex = LEVELS.indexOf(userLevel);
@@ -10,15 +13,30 @@ const shouldDisplayExplanation = ({ userLevel, wordLevel }) => {
   return userLevelIndex < wordLevelIndex;
 };
 
+const handleTerminologyWord = ({ word, settings, isClickable: explanation }) => {
+  const selectedOrderIndex = ORDERS.indexOf(settings.order);
+  const wordLevel = terminologies[word.toLowerCase().replaceAll(regexCharsToRemove, '')].level;
+  const userLevel = settings.level;
+  switch (selectedOrderIndex) {
+  case 0:
+    return `${word.replaceAll(regexCharsToRemove, '')} ${ shouldDisplayExplanation({ userLevel, wordLevel }) ? `(${explanation})` : ''} `;
+  case 1:
+    return `${explanation} ${ shouldDisplayExplanation({ userLevel, wordLevel }) ? `(${word.replaceAll(regexCharsToRemove, '')})` : ''} `;
+  case 2:
+    return `${explanation} `;
+  default:
+    console.error('Invalid selected order!', settings.order);
+  }
+};
+
 export const prepareClickableWords = ({ text, settings, action, terminologyClassName }) => {
   const words = text.split(' ');
-  const regexCharsToRemove = /[:.,()]/g;
 
   return words.map((word, index) => {
     const isClickable = terminologies[word.toLowerCase().replaceAll(regexCharsToRemove, '')]?.clarification?.en || false;
     const specialChars = isClickable ? word.match(regexCharsToRemove) : null;
     const specialCharPosition = (specialChars && specialChars[0]) ? word.indexOf(specialChars[0]) : null;
-    const wordWithPostfix = isClickable ? `${word.replaceAll(regexCharsToRemove, '')} ${ shouldDisplayExplanation({ userLevel: settings.level, wordLevel: terminologies[word.toLowerCase().replaceAll(regexCharsToRemove, '')].level }) ? `(${isClickable})` : ''} ` : word;
+    const wordWithPostfix = isClickable ? handleTerminologyWord({ word, settings, isClickable }) : word;
 
     if ( word.includes('http') ) {
       // eslint-disable-next-line react/jsx-no-target-blank

--- a/src/components/Hidayah/index.js
+++ b/src/components/Hidayah/index.js
@@ -5,7 +5,7 @@ import { useMemo, useState, useEffect } from 'preact/hooks';
 import PropTypes from 'prop-types';
 import terminologies from '@components/Content/terminologies.json';
 import { Fragment } from 'preact';
-import { LEVELS, DEFAULT_SETTINGS } from '@utils/constants';
+import { LEVELS, ORDERS, DEFAULT_SETTINGS } from '@utils/constants';
 import useLocalStorage from '@hooks/useLocalStorage';
 import style from './style.module.css';
 
@@ -30,12 +30,27 @@ const Levels = ({ level, setLevel }) => (<div>
   ))}
 </div>);
 
+const Ordering = ({ order, setOrder }) => (<div>
+  { ORDERS && ORDERS.map((ordr) => (
+    <>
+      <input type="radio" id={ordr} name={ordr} value={ordr} checked={ordr === order} onChange={() => setOrder(ordr)} />
+      <label key={ordr} for={ordr}>{ordr}</label>
+    </>
+  ))}
+</div>);
+
 const SettingsModal = ({ settings, setSettings, userId, hideModal, settingsModalClassName }) => (<div className={settingsModalClassName || style.popUpModal}>
   <button className={style.closeModalButton} onClick={hideModal}>X</button>
   <h3>Settings</h3>
   <h4>Levels:</h4>
   <Levels level={settings[userId].level} setLevel={(newLevel) => setSettings((old) => {
     old[userId].level = newLevel;
+    return { ...old };
+  })}
+  />
+  <h4>Ordering:</h4>
+  <Ordering order={settings[userId].order} setOrder={(newOrder) => setSettings((old) => {
+    old[userId].order = newOrder;
     return { ...old };
   })}
   />

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -5,6 +5,13 @@ export const LEVELS = [
   'expert'
 ];
 
+export const ORDERS = [
+  'Salah (prayer)',
+  'prayer (Salah)',
+  'prayer'
+];
+
 export const DEFAULT_SETTINGS = {
-  level: LEVELS[0]
+  level: LEVELS[0],
+  order: ORDERS[0]
 };


### PR DESCRIPTION
* Allow user to change the order of the terminology and the explanation, as the user can choose Salah (prayer) or prayer (Salah) or just plain prayer