### PR TITLE
combine all dependabot prs 2024 04 21 1755

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10587,9 +10587,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.740",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.740.tgz",
-      "integrity": "sha512-Yvg5i+iyv7Xm18BRdVPVm8lc7kgxM3r6iwqCH2zB7QZy1kZRNmd0Zqm0zcD9XoFREE5/5rwIuIAOT+/mzGcnZg==",
+      "version": "1.4.744",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.744.tgz",
+      "integrity": "sha512-nAGcF0yeKKfrP13LMFr5U1eghfFSvFLg302VUFzWlcjPOnUYd52yU5x6PBYrujhNbc4jYmZFrGZFK+xasaEzVA==",
       "dev": true
     },
     "node_modules/emittery": {


### PR DESCRIPTION
- Dependabot: Bump tocbot from 4.25.0 to 4.27.0
- Dependabot: Bump marked from 12.0.1 to 12.0.2
- Dependabot: Bump electron-to-chromium from 1.4.740 to 1.4.744
