### PR TITLE
combine all dependabot prs 2024 04 22 10347

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9230,9 +9230,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001611",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001611.tgz",
-      "integrity": "sha512-19NuN1/3PjA3QI8Eki55N8my4LzfkMCRLgCVfrl/slbSAchQfV0+GwjPrK3rq37As4UCLlM/DHajbKkAqbv92Q==",
+      "version": "1.0.30001612",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001612.tgz",
+      "integrity": "sha512-lFgnZ07UhaCcsSZgWW0K5j4e69dK1u/ltrL9lTUiFOwNHs12S3UMIEYgBV0Z6C6hRDev7iRnMzzYmKabYdXF9g==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
- Dependabot: Bump electron-to-chromium from 1.4.744 to 1.4.745
- Dependabot: Bump rollup from 4.14.3 to 4.16.1
- Dependabot: Bump vite from 5.2.9 to 5.2.10
- Dependabot: Bump nwsapi from 2.2.7 to 2.2.9
- Dependabot: Bump caniuse-lite from 1.0.30001611 to 1.0.30001612
