### PR TITLE
combine all dependabot prs 2024 04 24 1103

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20443,9 +20443,9 @@
       }
     },
     "node_modules/tocbot": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/tocbot/-/tocbot-4.27.0.tgz",
-      "integrity": "sha512-x3ZPNFPVOYCAyW4CEW8KszGfqB3/fnY1QX1tfUHH1fj1r6I8v0g5w0flNsWf7htZKtzqtdiPqu//II3ngL/WwA==",
+      "version": "4.27.4",
+      "resolved": "https://registry.npmjs.org/tocbot/-/tocbot-4.27.4.tgz",
+      "integrity": "sha512-RJMmos8JXMztNIaasVRyXc/eGQPE+APSkipNBJaFjLC++cYg6zCcRHQRy4EXncpiKiz1Nlax8RTsaSRJMam8CQ==",
       "dev": true
     },
     "node_modules/toidentifier": {


### PR DESCRIPTION
- Dependabot: Bump rollup from 4.16.3 to 4.16.4
- Dependabot: Bump electron-to-chromium from 1.4.746 to 1.4.747
- Dependabot: Bump babel-plugin-polyfill-regenerator from 0.6.1 to 0.6.2
- Dependabot: Bump flow-parser from 0.234.0 to 0.235.1
- Dependabot: Bump tocbot from 4.27.0 to 4.27.4
