### PR TITLE
combine all dependabot prs 2024 04 27 8363

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20443,9 +20443,9 @@
       }
     },
     "node_modules/tocbot": {
-      "version": "4.27.4",
-      "resolved": "https://registry.npmjs.org/tocbot/-/tocbot-4.27.4.tgz",
-      "integrity": "sha512-RJMmos8JXMztNIaasVRyXc/eGQPE+APSkipNBJaFjLC++cYg6zCcRHQRy4EXncpiKiz1Nlax8RTsaSRJMam8CQ==",
+      "version": "4.27.13",
+      "resolved": "https://registry.npmjs.org/tocbot/-/tocbot-4.27.13.tgz",
+      "integrity": "sha512-zS8GVVg14x/KBTxbvF6s3BNLltfMNZxTPaBpj+FjuwmnSv+ZK0trNN4uV5Ptw64NLFi2E30gt33+/a1Fkt3cWQ==",
       "dev": true
     },
     "node_modules/toidentifier": {


### PR DESCRIPTION
- Dependabot: Bump es-iterator-helpers from 1.0.18 to 1.0.19
- Dependabot: Bump react-dom from 18.2.0 to 18.3.0
- Dependabot: Bump scheduler from 0.23.0 to 0.23.1
- Dependabot: Bump react from 18.2.0 to 18.3.0
- Dependabot: Bump electron-to-chromium from 1.4.747 to 1.4.749
- Dependabot: Bump @types/react from 18.2.79 to 18.3.0
- Dependabot: Bump tocbot from 4.27.4 to 4.27.13
