### PR TITLE
combine all dependabot prs 2024 04 27 6918

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18610,9 +18610,9 @@
       }
     },
     "node_modules/react": {
-      "version": "18.3.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.0.tgz",
-      "integrity": "sha512-RPutkJftSAldDibyrjuku7q11d3oy6wKOyPe5K1HA/HwwrXcEqBdHsLypkC2FFYjP7bPUa6gbzSBhw4sY2JcDg==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -18633,17 +18633,17 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "18.3.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.0.tgz",
-      "integrity": "sha512-zaKdLBftQJnvb7FtDIpZtsAIb2MZU087RM8bRDZU8LVCCFYjPTsDZJNFUWPcVz3HFSN1n/caxi0ca4B/aaVQGQ==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "dev": true,
       "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.1"
+        "scheduler": "^0.23.2"
       },
       "peerDependencies": {
-        "react": "^18.3.0"
+        "react": "^18.3.1"
       }
     },
     "node_modules/react-is": {
@@ -19429,9 +19429,9 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.1.tgz",
-      "integrity": "sha512-5GKS5JGfiah1O38Vfa9srZE4s3wdHbwjlCrvIookrg2FO9aIwKLOJXuJQFlEfNcVSOXuaL2hzDeY20uVXcUtrw==",
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "dev": true,
       "peer": true,
       "dependencies": {


### PR DESCRIPTION
- Dependabot: Bump scheduler from 0.23.1 to 0.23.2
- Dependabot: Bump @types/react from 18.3.0 to 18.3.1
- Dependabot: Bump electron-to-chromium from 1.4.749 to 1.4.750
- Dependabot: Bump react from 18.3.0 to 18.3.1
- Dependabot: Bump react-dom from 18.3.0 to 18.3.1
