### PR TITLE
combine all dependabot prs 2024 04 30 5292

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9360,9 +9360,9 @@
       }
     },
     "node_modules/cjs-module-lexer": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
-      "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.3.1.tgz",
+      "integrity": "sha512-a3KdPAANPbNE4ZUv9h6LckSl9zLsYOP4MBmhIPkRaeyybt+r4UghLvq+xw/YwUcC1gqylCkL4rdVs3Lwupjm4Q==",
       "dev": true
     },
     "node_modules/clean-stack": {


### PR DESCRIPTION
- Dependabot: Bump rollup from 4.16.4 to 4.17.1
- Dependabot: Bump caniuse-lite from 1.0.30001612 to 1.0.30001614
- Dependabot: Bump @floating-ui/react-dom from 2.0.8 to 2.0.9
- Dependabot: Bump @floating-ui/core from 1.6.0 to 1.6.1
- Dependabot: Bump envinfo from 7.12.0 to 7.13.0
- Dependabot: Bump @floating-ui/utils from 0.2.1 to 0.2.2
- Dependabot: Bump @floating-ui/dom from 1.6.3 to 1.6.4
- Dependabot: Bump optionator from 0.9.3 to 0.9.4
- Dependabot: Bump cjs-module-lexer from 1.2.3 to 1.3.1
