### PR TITLE
combine all dependabot prs 2024 05 01 7441

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -299,12 +299,12 @@
       }
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.23.0.tgz",
-      "integrity": "sha512-6gfrPwh7OuT6gZyJZvd6WbTfrqAo7vm4xCzAXOusKqq/vWdKXphTpj5klHKNmRUU6/QRGlBsyU9mAIPaWHlqJA==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.24.5.tgz",
+      "integrity": "sha512-4owRteeihKWKamtqg4JmWSsEZU445xpFRXPEwp44HbgbxdWlUV1b4Agg4lkA806Lil5XM/e+FJyS0vj5T6vmcA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.23.0"
+        "@babel/types": "^7.24.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -442,9 +442,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.5.tgz",
+      "integrity": "sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -2135,13 +2135,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.0.tgz",
-      "integrity": "sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
+      "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-string-parser": "^7.23.4",
-        "@babel/helper-validator-identifier": "^7.22.20",
+        "@babel/helper-string-parser": "^7.24.1",
+        "@babel/helper-validator-identifier": "^7.24.5",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {


### PR DESCRIPTION
- Dependabot: Bump preact from 10.20.2 to 10.21.0
- Dependabot: Bump @babel/runtime from 7.24.4 to 7.24.5
- Dependabot: Bump @babel/plugin-transform-private-property-in-object
- Dependabot: Bump @babel/plugin-transform-typescript
- Dependabot: Bump @babel/parser from 7.24.4 to 7.24.5
- Dependabot: Bump @babel/plugin-transform-typeof-symbol
- Dependabot: Bump @babel/plugin-bugfix-firefox-class-in-computed-class-key
- Dependabot: Bump @babel/types from 7.24.0 to 7.24.5
- Dependabot: Bump @babel/helper-split-export-declaration
- Dependabot: Bump @babel/helper-module-transforms from 7.23.3 to 7.24.5
- Dependabot: Bump @babel/plugin-transform-classes from 7.24.1 to 7.24.5
- Dependabot: Bump @babel/plugin-transform-parameters
- Dependabot: Bump tough-cookie from 4.1.3 to 4.1.4
- Dependabot: Bump globalthis from 1.0.3 to 1.0.4
- Dependabot: Bump @babel/helpers from 7.24.4 to 7.24.5
- Dependabot: Bump @babel/helper-simple-access from 7.22.5 to 7.24.5
- Dependabot: Bump @babel/plugin-transform-optional-chaining
- Dependabot: Bump @babel/plugin-transform-destructuring
- Dependabot: Bump @babel/plugin-transform-block-scoping
- Dependabot: Bump @babel/preset-env from 7.24.4 to 7.24.5
- Dependabot: Bump rollup from 4.17.1 to 4.17.2
- Dependabot: Bump @babel/helper-wrap-function from 7.22.20 to 7.24.5
- Dependabot: Bump @babel/core from 7.24.4 to 7.24.5
- Dependabot: Bump @babel/traverse from 7.24.1 to 7.24.5
- Dependabot: Bump tocbot from 4.27.13 to 4.27.16
- Dependabot: Bump @babel/highlight from 7.24.2 to 7.24.5
- Dependabot: Bump @babel/generator from 7.24.4 to 7.24.5
- Dependabot: Bump electron-to-chromium from 1.4.750 to 1.4.751
- Dependabot: Bump @babel/plugin-transform-object-rest-spread
- Dependabot: Bump @babel/helper-member-expression-to-functions
