### PR TITLE
combine all dependabot prs 2024 05 03 6750

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20849,9 +20849,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
-      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.14.tgz",
+      "integrity": "sha512-JixKH8GR2pWYshIPUg/NujK3JO7JiqEEUiNArE86NQyrgUuZeTlZQN3xuS/yiV5Kb48ev9K6RqNkaJjXsdg7Jw==",
       "dev": true,
       "funding": [
         {
@@ -20868,7 +20868,7 @@
         }
       ],
       "dependencies": {
-        "escalade": "^3.1.1",
+        "escalade": "^3.1.2",
         "picocolors": "^1.0.0"
       },
       "bin": {


### PR DESCRIPTION
- Dependabot: Bump vite from 5.2.10 to 5.2.11
- Dependabot: Bump @types/emscripten from 1.39.10 to 1.39.11
- Dependabot: Bump tocbot from 4.27.16 to 4.27.18
- Dependabot: Bump electron-to-chromium from 1.4.752 to 1.4.754
- Dependabot: Bump caniuse-lite from 1.0.30001614 to 1.0.30001615
- Dependabot: Bump update-browserslist-db from 1.0.13 to 1.0.14
