### PR TITLE
combine all dependabot prs 2024 05 06 2686

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7170,9 +7170,9 @@
       }
     },
     "node_modules/@testing-library/jest-dom": {
-      "version": "6.4.3",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.4.3.tgz",
-      "integrity": "sha512-d1NUtNEN0hSUB/XWdF1GgdlD5S2tS0huQb2tkFL2usXRatR/EiHS6AhLtDcCb/iD9CS7kRmbAHt2O5JadkKyuA==",
+      "version": "6.4.5",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.4.5.tgz",
+      "integrity": "sha512-AguB9yvTXmCnySBP1lWjfNNUwpbElsaQ567lt2VdGqAdHtpieLgjmcVyv1q7PMIvLbgpDdkWV5Ydv3FEejyp2A==",
       "dev": true,
       "dependencies": {
         "@adobe/css-tools": "^4.3.2",


### PR DESCRIPTION
- Dependabot: Bump @storybook/preact from 8.0.9 to 8.0.10
- Dependabot: Bump update-browserslist-db from 1.0.14 to 1.0.15
- Dependabot: Bump electron-to-chromium from 1.4.754 to 1.4.756
- Dependabot: Bump @storybook/addon-links from 8.0.9 to 8.0.10
- Dependabot: Bump @types/lodash from 4.17.0 to 4.17.1
- Dependabot: Bump @floating-ui/dom from 1.6.4 to 1.6.5
- Dependabot: Bump tocbot from 4.27.18 to 4.27.19
- Dependabot: Bump caniuse-lite from 1.0.30001615 to 1.0.30001616
- Dependabot: Bump jake from 10.8.7 to 10.9.1
- Dependabot: Bump @testing-library/jest-dom from 6.4.3 to 6.4.5
