### PR TITLE
combine all dependabot prs 2024 05 09 7873

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20435,9 +20435,9 @@
       }
     },
     "node_modules/tocbot": {
-      "version": "4.27.19",
-      "resolved": "https://registry.npmjs.org/tocbot/-/tocbot-4.27.19.tgz",
-      "integrity": "sha512-0yu8k0L3gCQ1OVNZnKqpbZp+kLd6qtlNEBxsb+e0G/bS0EXMl2tWqWi1Oy9knRX8rTPYfOxd/sI/OzAj3JowGg==",
+      "version": "4.27.20",
+      "resolved": "https://registry.npmjs.org/tocbot/-/tocbot-4.27.20.tgz",
+      "integrity": "sha512-6M78FT20+FA5edtx7KowLvhG3gbZ6GRcEkL/0b2TcPbn6Ba+1ayI3SEVxe25zjkWGs0jd04InImaO81Hd8Hukw==",
       "dev": true
     },
     "node_modules/toidentifier": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@storybook/addon-links": "^8.0.0",
         "@storybook/blocks": "^8.0.0",
         "@storybook/preact": "^8.0.0",
-        "@storybook/preact-vite": "^7.6.17",
+        "@storybook/preact-vite": "^8.0.10",
         "@storybook/test": "^8.0.0",
         "@testing-library/preact": "^3.2.3",
         "babel-jest": "^29.7.0",
@@ -3788,115 +3788,6 @@
       "integrity": "sha512-j7P6Rgr3mmtdkeDGTe0E/aYyWEWVtc5yFXtHCRHs28/jptDEWfaVOc5T7cblqy1XKPPfCxJc/8DwQ5YgLOZOVQ==",
       "dev": true
     },
-    "node_modules/@preact/preset-vite": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/@preact/preset-vite/-/preset-vite-2.8.2.tgz",
-      "integrity": "sha512-m3tl+M8IO8jgiHnk+7LSTFl8axdPXloewi7iGVLdmCwf34XOzEUur0bZVewW4DUbUipFjTS2CXu27+5f/oexBA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/plugin-transform-react-jsx": "^7.22.15",
-        "@babel/plugin-transform-react-jsx-development": "^7.22.5",
-        "@prefresh/vite": "^2.4.1",
-        "@rollup/pluginutils": "^4.1.1",
-        "babel-plugin-transform-hook-names": "^1.0.2",
-        "debug": "^4.3.4",
-        "kolorist": "^1.8.0",
-        "magic-string": "0.30.5",
-        "node-html-parser": "^6.1.10",
-        "resolve": "^1.22.8",
-        "source-map": "^0.7.4",
-        "stack-trace": "^1.0.0-pre2"
-      },
-      "peerDependencies": {
-        "@babel/core": "7.x",
-        "vite": "2.x || 3.x || 4.x || 5.x"
-      }
-    },
-    "node_modules/@preact/preset-vite/node_modules/@rollup/pluginutils": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
-      "integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
-      "dev": true,
-      "dependencies": {
-        "estree-walker": "^2.0.1",
-        "picomatch": "^2.2.2"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      }
-    },
-    "node_modules/@preact/preset-vite/node_modules/magic-string": {
-      "version": "0.30.5",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
-      "integrity": "sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.4.15"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@preact/preset-vite/node_modules/source-map": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@prefresh/babel-plugin": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@prefresh/babel-plugin/-/babel-plugin-0.5.1.tgz",
-      "integrity": "sha512-uG3jGEAysxWoyG3XkYfjYHgaySFrSsaEb4GagLzYaxlydbuREtaX+FTxuIidp241RaLl85XoHg9Ej6E4+V1pcg==",
-      "dev": true
-    },
-    "node_modules/@prefresh/core": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@prefresh/core/-/core-1.5.2.tgz",
-      "integrity": "sha512-A/08vkaM1FogrCII5PZKCrygxSsc11obExBScm3JF1CryK2uDS3ZXeni7FeKCx1nYdUkj4UcJxzPzc1WliMzZA==",
-      "dev": true,
-      "peerDependencies": {
-        "preact": "^10.0.0"
-      }
-    },
-    "node_modules/@prefresh/utils": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@prefresh/utils/-/utils-1.2.0.tgz",
-      "integrity": "sha512-KtC/fZw+oqtwOLUFM9UtiitB0JsVX0zLKNyRTA332sqREqSALIIQQxdUCS1P3xR/jT1e2e8/5rwH6gdcMLEmsQ==",
-      "dev": true
-    },
-    "node_modules/@prefresh/vite": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/@prefresh/vite/-/vite-2.4.5.tgz",
-      "integrity": "sha512-iForDVJ2M8gQYnm5pHumvTEJjGGc7YNYC0GVKnHFL+GvFfKHfH9Rpq67nUAzNbjuLEpqEOUuQVQajMazWu2ZNQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/core": "^7.22.1",
-        "@prefresh/babel-plugin": "0.5.1",
-        "@prefresh/core": "^1.5.1",
-        "@prefresh/utils": "^1.2.0",
-        "@rollup/pluginutils": "^4.2.1"
-      },
-      "peerDependencies": {
-        "preact": "^10.4.0",
-        "vite": ">=2.0.0"
-      }
-    },
-    "node_modules/@prefresh/vite/node_modules/@rollup/pluginutils": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
-      "integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
-      "dev": true,
-      "dependencies": {
-        "estree-walker": "^2.0.1",
-        "picomatch": "^2.2.2"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      }
-    },
     "node_modules/@radix-ui/number": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.0.1.tgz",
@@ -5519,19 +5410,20 @@
       }
     },
     "node_modules/@storybook/builder-vite": {
-      "version": "7.6.17",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-7.6.17.tgz",
-      "integrity": "sha512-2Q32qalI401EsKKr9Hkk8TAOcHEerqwsjCpQgTNJnCu6GgCVKoVUcb99oRbR9Vyg0xh+jb19XiWqqQujFtLYlQ==",
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-8.0.10.tgz",
+      "integrity": "sha512-Rod/2jYvF4Ng1MjIMZEXe/3z0lPuxkRtetCTr3ECPgi83lHXpHJ+N0NVfJEMs+pXsVqkLP3iGt2hLn6D6yFMwA==",
       "dev": true,
       "dependencies": {
-        "@storybook/channels": "7.6.17",
-        "@storybook/client-logger": "7.6.17",
-        "@storybook/core-common": "7.6.17",
-        "@storybook/csf-plugin": "7.6.17",
-        "@storybook/node-logger": "7.6.17",
-        "@storybook/preview": "7.6.17",
-        "@storybook/preview-api": "7.6.17",
-        "@storybook/types": "7.6.17",
+        "@storybook/channels": "8.0.10",
+        "@storybook/client-logger": "8.0.10",
+        "@storybook/core-common": "8.0.10",
+        "@storybook/core-events": "8.0.10",
+        "@storybook/csf-plugin": "8.0.10",
+        "@storybook/node-logger": "8.0.10",
+        "@storybook/preview": "8.0.10",
+        "@storybook/preview-api": "8.0.10",
+        "@storybook/types": "8.0.10",
         "@types/find-cache-dir": "^3.2.1",
         "browser-assert": "^1.2.1",
         "es-module-lexer": "^0.9.3",
@@ -5539,7 +5431,7 @@
         "find-cache-dir": "^3.0.0",
         "fs-extra": "^11.1.0",
         "magic-string": "^0.30.0",
-        "rollup": "^2.25.0 || ^3.3.0"
+        "ts-dedent": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -5548,7 +5440,7 @@
       "peerDependencies": {
         "@preact/preset-vite": "*",
         "typescript": ">= 4.3.x",
-        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0",
+        "vite": "^4.0.0 || ^5.0.0",
         "vite-plugin-glimmerx": "*"
       },
       "peerDependenciesMeta": {
@@ -5563,20 +5455,292 @@
         }
       }
     },
-    "node_modules/@storybook/builder-vite/node_modules/rollup": {
-      "version": "3.29.4",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.4.tgz",
-      "integrity": "sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==",
+    "node_modules/@storybook/builder-vite/node_modules/@storybook/channels": {
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-8.0.10.tgz",
+      "integrity": "sha512-3JLxfD7czlx31dAGvAYJ4J4BNE/Y2+hhj/dsV3xlQTHKVpnWknaoeYEC1a6YScyfsH6W+XmP2rzZKzH4EkLSGQ==",
       "dev": true,
-      "bin": {
-        "rollup": "dist/bin/rollup"
+      "dependencies": {
+        "@storybook/client-logger": "8.0.10",
+        "@storybook/core-events": "8.0.10",
+        "@storybook/global": "^5.0.0",
+        "telejson": "^7.2.0",
+        "tiny-invariant": "^1.3.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/builder-vite/node_modules/@storybook/client-logger": {
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-8.0.10.tgz",
+      "integrity": "sha512-u38SbZNAunZzxZNHMJb9jkUwFkLyWxmvp4xtiRM3u9sMUShXoTnzbw1yKrxs+kYJjg+58UQPZ1JhEBRcHt5Oww==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/global": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/builder-vite/node_modules/@storybook/core-common": {
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/@storybook/core-common/-/core-common-8.0.10.tgz",
+      "integrity": "sha512-hsFlPieputaDQoxstnPa3pykTc4bUwEDgCHf8U43+/Z7qmLOQ9fpG+2CFW930rsCRghYpPreOvsmhY7lsGKWLQ==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/core-events": "8.0.10",
+        "@storybook/csf-tools": "8.0.10",
+        "@storybook/node-logger": "8.0.10",
+        "@storybook/types": "8.0.10",
+        "@yarnpkg/fslib": "2.10.3",
+        "@yarnpkg/libzip": "2.3.0",
+        "chalk": "^4.1.0",
+        "cross-spawn": "^7.0.3",
+        "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0",
+        "esbuild-register": "^3.5.0",
+        "execa": "^5.0.0",
+        "file-system-cache": "2.3.0",
+        "find-cache-dir": "^3.0.0",
+        "find-up": "^5.0.0",
+        "fs-extra": "^11.1.0",
+        "glob": "^10.0.0",
+        "handlebars": "^4.7.7",
+        "lazy-universal-dotenv": "^4.0.0",
+        "node-fetch": "^2.0.0",
+        "picomatch": "^2.3.0",
+        "pkg-dir": "^5.0.0",
+        "pretty-hrtime": "^1.0.3",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.3.7",
+        "tempy": "^1.0.1",
+        "tiny-invariant": "^1.3.1",
+        "ts-dedent": "^2.0.0",
+        "util": "^0.12.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/builder-vite/node_modules/@storybook/core-events": {
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-8.0.10.tgz",
+      "integrity": "sha512-TuHPS6p5ZNr4vp4butLb4R98aFx0NRYCI/7VPhJEUH5rPiqNzE3PZd8DC8rnVxavsJ+jO1/y+egNKXRYkEcoPQ==",
+      "dev": true,
+      "dependencies": {
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/builder-vite/node_modules/@storybook/csf-plugin": {
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-8.0.10.tgz",
+      "integrity": "sha512-0EsyEx/06sCjI8sn40r7cABtBU1vUKPMPD+S5mJiZymm73BgdARj0qZOlLoK2LP+t2pcaB/Cn7KX/uyhhv7M2g==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/csf-tools": "8.0.10",
+        "unplugin": "^1.3.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/builder-vite/node_modules/@storybook/csf-tools": {
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-tools/-/csf-tools-8.0.10.tgz",
+      "integrity": "sha512-xUc6fVIKoCujf/7JZhkYjrVXeNsTSoDrZFNmqLEmtfktJVqYdXY4LuSAtlBmAIyETi09ULTuuVexrcKFwjzuBA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/generator": "^7.23.0",
+        "@babel/parser": "^7.23.0",
+        "@babel/traverse": "^7.23.2",
+        "@babel/types": "^7.23.0",
+        "@storybook/csf": "^0.1.4",
+        "@storybook/types": "8.0.10",
+        "fs-extra": "^11.1.0",
+        "recast": "^0.23.5",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/builder-vite/node_modules/@storybook/node-logger": {
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-8.0.10.tgz",
+      "integrity": "sha512-UMmaUaA3VOX/mKLsSvOnbZre2/1tZ6hazA6H0eAnClKb51jRD1AJrsBYK+uHr/CAp7t710bB5U8apPov7hayDw==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/builder-vite/node_modules/@storybook/preview-api": {
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/@storybook/preview-api/-/preview-api-8.0.10.tgz",
+      "integrity": "sha512-uZ6btF7Iloz9TnDcKLQ5ydi2YK0cnulv/8FLQhBCwSrzLLLb+T2DGz0cAeuWZEvMUNWNmkWJ9PAFQFs09/8p/Q==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/channels": "8.0.10",
+        "@storybook/client-logger": "8.0.10",
+        "@storybook/core-events": "8.0.10",
+        "@storybook/csf": "^0.1.4",
+        "@storybook/global": "^5.0.0",
+        "@storybook/types": "8.0.10",
+        "@types/qs": "^6.9.5",
+        "dequal": "^2.0.2",
+        "lodash": "^4.17.21",
+        "memoizerific": "^1.11.3",
+        "qs": "^6.10.0",
+        "tiny-invariant": "^1.3.1",
+        "ts-dedent": "^2.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/builder-vite/node_modules/@storybook/types": {
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/@storybook/types/-/types-8.0.10.tgz",
+      "integrity": "sha512-S/hKS7+SqNnYIehwxdQ4M2nnlfGDdYWAXdtPCVJCmS+YF2amgAxeuisiHbUg7eypds6VL0Oxk/j2nPEHOHk9pg==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/channels": "8.0.10",
+        "@types/express": "^4.7.0",
+        "file-system-cache": "2.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/builder-vite/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
       },
       "engines": {
-        "node": ">=14.18.0",
-        "npm": ">=8.0.0"
+        "node": ">=8"
       },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@storybook/builder-vite/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@storybook/builder-vite/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@storybook/builder-vite/node_modules/glob": {
+      "version": "10.3.12",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.12.tgz",
+      "integrity": "sha512-TCNv8vJ+xz4QiqTpfOJA7HvYv+tNIRHKfUWw/q+v2jdgN4ebz+KY9tGx5J4rHP0o84mNP+ApH66HRX8us3Khqg==",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^2.3.6",
+        "minimatch": "^9.0.1",
+        "minipass": "^7.0.4",
+        "path-scurry": "^1.10.2"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@storybook/builder-vite/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@storybook/builder-vite/node_modules/minimatch": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@storybook/builder-vite/node_modules/minipass": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.0.tgz",
+      "integrity": "sha512-oGZRv2OT1lO2UF1zUcwdTb3wqUwI0kBGTgt/T7OdSj6M6N5m3o5uPf0AIW6lVxGGoiWUR7e2AwTE+xiwK8WQig==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/@storybook/builder-vite/node_modules/semver": {
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.1.tgz",
+      "integrity": "sha512-f/vbBsu+fOiYt+lmwZV0rVwJScl46HppnOA1ZvIuBWKOTlllpyJ3bfVax76/OrhCH38dyxoDIA8K7uB963IYgA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@storybook/builder-vite/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@storybook/channels": {
@@ -5801,20 +5965,6 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@storybook/core-client": {
-      "version": "7.6.17",
-      "resolved": "https://registry.npmjs.org/@storybook/core-client/-/core-client-7.6.17.tgz",
-      "integrity": "sha512-LuDbADK+DPNAOOCXOlvY09hdGVueXlDetsdOJ/DgYnSa9QSWv9Uv+F8QcEgR3QckZJbPlztKJIVLgP2n/Xkijw==",
-      "dev": true,
-      "dependencies": {
-        "@storybook/client-logger": "7.6.17",
-        "@storybook/preview-api": "7.6.17"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
       }
     },
     "node_modules/@storybook/core-common": {
@@ -6691,17 +6841,16 @@
       }
     },
     "node_modules/@storybook/preact-vite": {
-      "version": "7.6.17",
-      "resolved": "https://registry.npmjs.org/@storybook/preact-vite/-/preact-vite-7.6.17.tgz",
-      "integrity": "sha512-ZPOAxx7xBJ85L4PR+JkYiQcmoIXkEpZYkTXPyx331owBqWEos9hdf0WfVtnBa57fDwsbkKGY+uhmqbPrYPa5eA==",
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/@storybook/preact-vite/-/preact-vite-8.0.10.tgz",
+      "integrity": "sha512-6W4iG1/UYIg8Vk+GzDqsJu2ssTUknP9b4MoSWdNUL4YcRr98dV965fWJ1JhOUqmanNPhh7DHuSUOd2V6tbjKSQ==",
       "dev": true,
       "dependencies": {
-        "@preact/preset-vite": "^2.0.0",
-        "@storybook/builder-vite": "7.6.17",
-        "@storybook/preact": "7.6.17"
+        "@storybook/builder-vite": "8.0.10",
+        "@storybook/preact": "8.0.10"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -6709,30 +6858,7 @@
       },
       "peerDependencies": {
         "preact": ">=10",
-        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0"
-      }
-    },
-    "node_modules/@storybook/preact-vite/node_modules/@storybook/preact": {
-      "version": "7.6.17",
-      "resolved": "https://registry.npmjs.org/@storybook/preact/-/preact-7.6.17.tgz",
-      "integrity": "sha512-12F5rAJdqiLZ677VfuCB9lerfZV4H0y8ai03x0rHI53a23O/7GIkzII4JwE0KgWrBPDp8KNv4Q26DsCnqulpjw==",
-      "dev": true,
-      "dependencies": {
-        "@storybook/core-client": "7.6.17",
-        "@storybook/global": "^5.0.0",
-        "@storybook/preview-api": "7.6.17",
-        "@storybook/types": "7.6.17",
-        "ts-dedent": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "preact": "^8.0.0||^10.0.0"
+        "vite": "^4.0.0 || ^5.0.0"
       }
     },
     "node_modules/@storybook/preact/node_modules/@storybook/channels": {
@@ -6820,9 +6946,9 @@
       }
     },
     "node_modules/@storybook/preview": {
-      "version": "7.6.17",
-      "resolved": "https://registry.npmjs.org/@storybook/preview/-/preview-7.6.17.tgz",
-      "integrity": "sha512-LvkMYK/y6alGjwRVNDIKL1lFlbyZ0H0c8iAbcQkiMoaFiujMQyVswMDKlWcj42Upfr/B1igydiruomc+eUt0mw==",
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/@storybook/preview/-/preview-8.0.10.tgz",
+      "integrity": "sha512-op7gZqop8PSFyPA4tc1Zds8jG6VnskwpYUUsa44pZoEez9PKEFCf4jE+7AQwbBS3hnuCb0CKBfASN8GRyoznbw==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -8246,12 +8372,12 @@
       }
     },
     "node_modules/address": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/address/-/address-1.2.2.tgz",
-      "integrity": "sha512-4B/qKCfeE/ODUaAUpSwfzazo5x29WD4r3vXiWsB7I2mSDAihwEqKO+g8GELZUQSSAo5e1XTYh3ZVfLyxBc12nA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/address/-/address-2.0.2.tgz",
+      "integrity": "sha512-u6nFssvaX9RHQmjMSqgT7b7QJbf/5/U8+ntbTL8vgABfIiEmm02ZSM5MwljKjCrIrm7iIbgYEya2YW6AaRccVA==",
       "dev": true,
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">= 16.0.0"
       }
     },
     "node_modules/agent-base": {
@@ -8842,15 +8968,6 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
       "integrity": "sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw==",
       "dev": true
-    },
-    "node_modules/babel-plugin-transform-hook-names": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-hook-names/-/babel-plugin-transform-hook-names-1.0.2.tgz",
-      "integrity": "sha512-5gafyjyyBTTdX/tQQ0hRgu4AhNHG/hqWi0ZZmg2xvs2FgRkJXzDNKBZCyoYqgFkovfDrgM8OoKg8karoUvWeCw==",
-      "dev": true,
-      "peerDependencies": {
-        "@babel/core": "^7.12.10"
-      }
     },
     "node_modules/babel-preset-current-node-syntax": {
       "version": "1.0.1",
@@ -10352,17 +10469,19 @@
       }
     },
     "node_modules/detect-port": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.5.1.tgz",
-      "integrity": "sha512-aBzdj76lueB6uUst5iAs7+0H/oOjqI5D16XUWxlWMIMROhcM0rfsNVk93zTngq1dDNpoXRr++Sus7ETAExppAQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.6.0.tgz",
+      "integrity": "sha512-iKO0phS1ebSLst7ULM1hw4qjndYHqyKe76Pk0q+QDvoANFth/f9Pp6oSZzOIM367SeRi+ufseIGvIiThTPERSg==",
       "dev": true,
       "dependencies": {
-        "address": "^1.0.1",
-        "debug": "4"
+        "address": "^2.0.2"
       },
       "bin": {
         "detect": "bin/detect-port.js",
         "detect-port": "bin/detect-port.js"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/diff-sequences": {
@@ -10578,9 +10697,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.757",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.757.tgz",
-      "integrity": "sha512-jftDaCknYSSt/+KKeXzH3LX5E2CvRLm75P3Hj+J/dv3CL0qUYcOt13d5FN1NiL5IJbbhzHrb3BomeG2tkSlZmw==",
+      "version": "1.4.758",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.758.tgz",
+      "integrity": "sha512-/o9x6TCdrYZBMdGeTifAP3wlF/gVT+TtWJe3BSmtNh92Mw81U9hrYwW9OAGUh+sEOX/yz5e34sksqRruZbjYrw==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -12638,15 +12757,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/he": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-      "dev": true,
-      "bin": {
-        "he": "bin/he"
       }
     },
     "node_modules/hosted-git-info": {
@@ -16080,12 +16190,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/kolorist": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/kolorist/-/kolorist-1.8.0.tgz",
-      "integrity": "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==",
-      "dev": true
-    },
     "node_modules/lazy-universal-dotenv": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/lazy-universal-dotenv/-/lazy-universal-dotenv-4.0.0.tgz",
@@ -16721,75 +16825,6 @@
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
-      }
-    },
-    "node_modules/node-html-parser": {
-      "version": "6.1.12",
-      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-6.1.12.tgz",
-      "integrity": "sha512-/bT/Ncmv+fbMGX96XG9g05vFt43m/+SYKIs9oAemQVYyVcZmDAI2Xq/SbNcpOA35eF0Zk2av3Ksf+Xk8Vt8abA==",
-      "dev": true,
-      "dependencies": {
-        "css-select": "^5.1.0",
-        "he": "1.2.0"
-      }
-    },
-    "node_modules/node-html-parser/node_modules/css-select": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
-      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
-      "dev": true,
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-what": "^6.1.0",
-        "domhandler": "^5.0.2",
-        "domutils": "^3.0.1",
-        "nth-check": "^2.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/node-html-parser/node_modules/dom-serializer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-      "dev": true,
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.2",
-        "entities": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/node-html-parser/node_modules/domhandler": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-      "dev": true,
-      "dependencies": {
-        "domelementtype": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/node-html-parser/node_modules/domutils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
-      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
-      "dev": true,
-      "dependencies": {
-        "dom-serializer": "^2.0.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/node-int64": {
@@ -19758,15 +19793,6 @@
       "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
       "deprecated": "Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility",
       "dev": true
-    },
-    "node_modules/stack-trace": {
-      "version": "1.0.0-pre2",
-      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-1.0.0-pre2.tgz",
-      "integrity": "sha512-2ztBJRek8IVofG9DBJqdy2N5kulaacX30Nz7xmkYF6ale9WBVmIy6mFBchvGX7Vx/MyjBhx+Rcxqrj+dbOnQ6A==",
-      "dev": true,
-      "engines": {
-        "node": ">=16"
-      }
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@storybook/addon-links": "^8.0.0",
     "@storybook/blocks": "^8.0.0",
     "@storybook/preact": "^8.0.0",
-    "@storybook/preact-vite": "^7.6.17",
+    "@storybook/preact-vite": "^8.0.10",
     "@storybook/test": "^8.0.0",
     "@testing-library/preact": "^3.2.3",
     "babel-jest": "^29.7.0",


### PR DESCRIPTION
- Dependabot: Bump electron-to-chromium from 1.4.757 to 1.4.758
- Dependabot: Bump @storybook/preact-vite from 7.6.17 to 8.0.10
- Dependabot: Bump detect-port from 1.5.1 to 1.6.0
- Dependabot: Bump tocbot from 4.27.19 to 4.27.20
