### PR TITLE
combine all dependabot prs 2024 05 15 9998

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10160,9 +10160,9 @@
       }
     },
     "node_modules/core-js-compat": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.37.0.tgz",
-      "integrity": "sha512-vYq4L+T8aS5UuFg4UwDhc7YNRWVeVZwltad9C/jV3R2LgVOpS9BDr7l/WL6BN0dbV3k1XejPTHqqEzJgsa0frA==",
+      "version": "3.37.1",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.37.1.tgz",
+      "integrity": "sha512-9TNiImhKvQqSUkOvk/mMRZzOANTiEVC7WaBNhHcKM7x+/5E1l5NvsysR19zuDQScE8k+kfQXWRN3AtS/eOSHpg==",
       "dev": true,
       "dependencies": {
         "browserslist": "^4.23.0"


### PR DESCRIPTION
- Dependabot: Bump flow-parser from 0.235.1 to 0.236.0
- Dependabot: Bump @types/react from 18.3.1 to 18.3.2
- Dependabot: Bump path-scurry from 1.10.2 to 1.11.1
- Dependabot: Bump nwsapi from 2.2.9 to 2.2.10
- Dependabot: Bump recast from 0.23.6 to 0.23.7
- Dependabot: Bump cli-table3 from 0.6.4 to 0.6.5
- Dependabot: Bump @storybook/blocks from 8.0.10 to 8.1.0
- Dependabot: Bump @storybook/preact from 8.0.10 to 8.1.0
- Dependabot: Bump electron-to-chromium from 1.4.762 to 1.4.768
- Dependabot: Bump picocolors from 1.0.0 to 1.0.1
- Dependabot: Bump @types/emscripten from 1.39.11 to 1.39.12
- Dependabot: Bump update-browserslist-db from 1.0.15 to 1.0.16
- Dependabot: Bump @storybook/addon-links from 8.0.10 to 8.1.0
- Dependabot: Bump caniuse-lite from 1.0.30001617 to 1.0.30001618
- Dependabot: Bump core-js from 3.37.0 to 3.37.1
- Dependabot: Bump core-js-compat from 3.37.0 to 3.37.1
