### PR TITLE
combine all dependabot prs 2024 05 16 9555

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18791,9 +18791,9 @@
       "dev": true
     },
     "node_modules/preact": {
-      "version": "10.21.0",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.21.0.tgz",
-      "integrity": "sha512-aQAIxtzWEwH8ou+OovWVSVNlFImL7xUCwJX3YMqA3U8iKCNC34999fFOnWjYNsylgfPgMexpbk7WYOLtKr/mxg==",
+      "version": "10.22.0",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.22.0.tgz",
+      "integrity": "sha512-RRurnSjJPj4rp5K6XoP45Ui33ncb7e4H7WiOHVpjbkvqvA3U+N8Z6Qbo0AE6leGYBV66n8EhEaFixvIu3SkxFw==",
       "dev": true,
       "funding": {
         "type": "opencollective",


### PR DESCRIPTION
- Dependabot: Bump electron-to-chromium from 1.4.768 to 1.4.769
- Dependabot: Bump @storybook/test from 8.0.10 to 8.1.0
- Dependabot: Bump preact from 10.21.0 to 10.22.0
