### PR TITLE
combine all dependabot prs 2024 05 19 8097

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11169,9 +11169,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.769",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.769.tgz",
-      "integrity": "sha512-bZu7p623NEA2rHTc9K1vykl57ektSPQYFFqQir8BOYf6EKOB+yIsbFB9Kpm7Cgt6tsLr9sRkqfqSZUw7LP1XxQ==",
+      "version": "1.4.773",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.773.tgz",
+      "integrity": "sha512-87eHF+h3PlCRwbxVEAw9KtK3v7lWfc/sUDr0W76955AdYTG4bV/k0zrl585Qnj/skRMH2qOSiE+kqMeOQ+LOpw==",
       "dev": true
     },
     "node_modules/emittery": {


### PR DESCRIPTION
- Dependabot: Bump @storybook/test from 8.1.0 to 8.1.1
- Dependabot: Bump @storybook/preact from 8.1.0 to 8.1.1
- Dependabot: Bump @floating-ui/core from 1.6.1 to 1.6.2
- Dependabot: Bump @storybook/blocks from 8.1.0 to 8.1.1
- Dependabot: Bump caniuse-lite from 1.0.30001618 to 1.0.30001620
- Dependabot: Bump @storybook/addon-links from 8.1.0 to 8.1.1
- Dependabot: Bump @types/lodash from 4.17.1 to 4.17.4
- Dependabot: Bump electron-to-chromium from 1.4.769 to 1.4.773
