### PR TITLE
combine all dependabot prs 2024 05 24 8007

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11187,9 +11187,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.779",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.779.tgz",
-      "integrity": "sha512-oaTiIcszNfySXVJzKcjxd2YjPxziAd+GmXyb2HbidCeFo6Z88ygOT7EimlrEQhM2U08VhSrbKhLOXP0kKUCZ6g==",
+      "version": "1.4.781",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.781.tgz",
+      "integrity": "sha512-aBI40ltvcWJQDW+V803FY6HjXAfi5xCWzpa3vSM/NGg7GfKEvI7ftzW4Gb2XKTRO4WsxDG7YG8ykrr/pG9bkKQ==",
       "dev": true
     },
     "node_modules/emittery": {


### PR DESCRIPTION
- Dependabot: Bump tocbot from 4.28.0 to 4.28.2
- Dependabot: Bump electron-to-chromium from 1.4.779 to 1.4.781
