### PR TITLE
combine all dependabot prs 2024 05 28 7212

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -169,12 +169,12 @@
       }
     },
     "node_modules/@babel/helper-annotate-as-pure": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.22.5.tgz",
-      "integrity": "sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.24.6.tgz",
+      "integrity": "sha512-DitEzDfOMnd13kZnDqns1ccmftwJTS9DMkyn9pYTxulS7bZxUxpMly3Nf23QQ6NwA4UB8lAqjbqWtyvElEMAkg==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.22.5"
+        "@babel/types": "^7.24.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -433,18 +433,18 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.1.tgz",
-      "integrity": "sha512-2ofRCjnnA9y+wk8b9IAREroeUP02KHp431N2mhKniy2yKIDKpbrHv9eXwm8cBeWQYcJmzv5qKCu65P47eCF7CQ==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.6.tgz",
+      "integrity": "sha512-WdJjwMEkmBicq5T9fm/cHND3+UlFa2Yj8ALLgmoSQAJZysYbBjw+azChSGPN4DSPLXOcooGRvDwZWMcF/mLO2Q==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.5.tgz",
-      "integrity": "sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.6.tgz",
+      "integrity": "sha512-4yA7s865JHaqUdRbnaxarZREuPTHrjpDT+pXoAZ1yhyo6uFnIEpS8VMu16siFOHDpZNKYv5BObhsB//ycbICyw==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -2135,13 +2135,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
-      "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.6.tgz",
+      "integrity": "sha512-WaMsgi6Q8zMgMth93GvWPXkhAIEobfsIkLTacoVZoK1J0CevIPGYY2Vo5YvJGqyHqXM6P4ppOYGsIRU8MM9pFQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-string-parser": "^7.24.1",
-        "@babel/helper-validator-identifier": "^7.24.5",
+        "@babel/helper-string-parser": "^7.24.6",
+        "@babel/helper-validator-identifier": "^7.24.6",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {


### PR DESCRIPTION
- Dependabot: Bump preact-render-to-string from 6.5.2 to 6.5.3
- Dependabot: Bump @babel/generator from 7.24.5 to 7.24.6
- Dependabot: Bump @babel/helper-hoist-variables from 7.22.5 to 7.24.6
- Dependabot: Bump @babel/plugin-transform-optional-catch-binding
- Dependabot: Bump @babel/plugin-syntax-import-assertions
- Dependabot: Bump @babel/register from 7.23.7 to 7.24.6
- Dependabot: Bump @babel/plugin-transform-duplicate-keys
- Dependabot: Bump @babel/template from 7.24.0 to 7.24.6
- Dependabot: Bump @babel/plugin-transform-unicode-property-regex
- Dependabot: Bump @babel/helper-simple-access from 7.24.5 to 7.24.6
- Dependabot: Bump @babel/plugin-transform-private-property-in-object
- Dependabot: Bump @babel/plugin-transform-async-generator-functions
- Dependabot: Bump @babel/plugin-transform-computed-properties
- Dependabot: Bump @babel/helper-builder-binary-assignment-operator-visitor
- Dependabot: Bump @babel/plugin-syntax-typescript from 7.24.1 to 7.24.6
- Dependabot: Bump @babel/plugin-transform-sticky-regex
- Dependabot: Bump @babel/plugin-transform-typescript
- Dependabot: Bump @babel/plugin-transform-modules-umd
- Dependabot: Bump @babel/plugin-transform-new-target
- Dependabot: Bump @babel/code-frame from 7.24.2 to 7.24.6
- Dependabot: Bump @babel/plugin-transform-classes from 7.24.5 to 7.24.6
- Dependabot: Bump @babel/plugin-transform-typeof-symbol
- Dependabot: Bump @babel/helpers from 7.24.5 to 7.24.6
- Dependabot: Bump @babel/plugin-transform-function-name
- Dependabot: Bump @babel/helper-validator-identifier
- Dependabot: Bump @babel/plugin-transform-reserved-words
- Dependabot: Bump @babel/plugin-transform-unicode-sets-regex
- Dependabot: Bump @babel/helper-function-name from 7.23.0 to 7.24.6
- Dependabot: Bump caniuse-lite from 1.0.30001621 to 1.0.30001623
- Dependabot: Bump @babel/helper-annotate-as-pure from 7.22.5 to 7.24.6
