### PR TITLE
combine all dependabot prs 2024 05 29 5168

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -712,12 +712,12 @@
       }
     },
     "node_modules/@babel/plugin-syntax-import-attributes": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.24.1.tgz",
-      "integrity": "sha512-zhQTMH0X2nVLnb04tz+s7AMuasX8U0FnpE+nHTOhSOINjWMnopoZTxtIKsd45n4GQ/HIZLyfIpoul8e2m0DnRA==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.24.6.tgz",
+      "integrity": "sha512-D+CfsVZousPXIdudSII7RGy52+dYRtbyKAZcvtQKq/NpsivyMVduepzcLqG5pMBugtMdedxdC8Ramdpcne9ZWQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.0"
+        "@babel/helper-plugin-utils": "^7.24.6"
       },
       "engines": {
         "node": ">=6.9.0"


### PR DESCRIPTION
- Dependabot: Bump @babel/plugin-transform-async-to-generator
- Dependabot: Bump @babel/plugin-transform-react-pure-annotations
- Dependabot: Bump @babel/traverse from 7.24.5 to 7.24.6
- Dependabot: Bump @babel/plugin-transform-named-capturing-groups-regex
- Dependabot: Bump @babel/plugin-transform-object-rest-spread
- Dependabot: Bump @babel/preset-react from 7.24.1 to 7.24.6
- Dependabot: Bump @babel/core from 7.24.5 to 7.24.6
- Dependabot: Bump @babel/plugin-transform-template-literals
- Dependabot: Bump @storybook/blocks from 8.1.3 to 8.1.4
- Dependabot: Bump @babel/plugin-bugfix-firefox-class-in-computed-class-key
- Dependabot: Bump @babel/plugin-transform-block-scoped-functions
- Dependabot: Bump eslint-plugin-react from 7.34.1 to 7.34.2
- Dependabot: Bump @storybook/test from 8.1.3 to 8.1.4
- Dependabot: Bump @babel/plugin-transform-dynamic-import
- Dependabot: Bump @babel/preset-flow from 7.24.1 to 7.24.6
- Dependabot: Bump @babel/plugin-transform-modules-amd
- Dependabot: Bump @babel/plugin-transform-for-of from 7.24.1 to 7.24.6
- Dependabot: Bump @storybook/addon-links from 8.1.3 to 8.1.4
- Dependabot: Bump @babel/preset-env from 7.24.5 to 7.24.6
- Dependabot: Bump @babel/plugin-transform-private-methods
- Dependabot: Bump @babel/plugin-transform-object-super
- Dependabot: Bump @babel/plugin-transform-shorthand-properties
- Dependabot: Bump @babel/plugin-transform-block-scoping
- Dependabot: Bump @babel/plugin-transform-parameters
- Dependabot: Bump @babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression
- Dependabot: Bump @babel/plugin-syntax-import-attributes
