### PR TITLE
Fix links in md files

### DIFF
--- a/contents/hanafi/en/8_ruling_bleeding_most_likely_istihadah.md
+++ b/contents/hanafi/en/8_ruling_bleeding_most_likely_istihadah.md
@@ -8,7 +8,7 @@
     - Fasting during Ramadan.
     - Tilawah of Quran.
 - Renew Wudu whenever bleeding/spotting occurs. If this happens during Salaah, then Salaah breaks and must be restarted.
-- If bleeding frequency prevents completion of Salaah, follow the guidelines for Ma’dhur as detailed in this link: <https://mensesmatters.org/rulings-for-the-excused-madhur>
+- If bleeding frequency prevents completion of Salaah, follow the guidelines for Ma’dhur as detailed in this link: https://mensesmatters.org/rulings-for-the-excused-madhur
 
 ## Additional Clarifications
 
@@ -24,4 +24,4 @@
 
 ## Marital Clarifications
 
-- One ought to abstain from conjugal relationships during this time. For more information, kindly follow this link: <https://mensesmatters.org/intercourse-during-early-blood/>
+- One ought to abstain from conjugal relationships during this time. For more information, kindly follow this link: https://mensesmatters.org/intercourse-during-early-blood/


### PR DESCRIPTION
* Fix an issue where links in the md file contained `<` and `>` characters, which prevented the links from opening correctly.
* The browser mistakenly interpreted these as internal links.