### PR TITLE
combine all dependabot prs 2024 05 30 1937

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9826,9 +9826,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001623",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001623.tgz",
-      "integrity": "sha512-X/XhAVKlpIxWPpgRTnlgZssJrF0m6YtRA0QDWgsBNT12uZM6LPRydR7ip405Y3t1LamD8cP2TZFEDZFBf5ApcA==",
+      "version": "1.0.30001625",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001625.tgz",
+      "integrity": "sha512-4KE9N2gcRH+HQhpeiRZXd+1niLB/XNLAhSy4z7fI8EzcbcPoAqjNInxVHTiTwWfTIV4w096XG8OtCOCQQKPv3w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
- Dependabot: Bump @types/emscripten from 1.39.12 to 1.39.13
- Dependabot: Bump vite from 5.2.11 to 5.2.12
- Dependabot: Bump flow-parser from 0.236.0 to 0.237.0
- Dependabot: Bump @testing-library/preact from 3.2.3 to 3.2.4
- Dependabot: Bump @storybook/preact from 8.1.3 to 8.1.4
- Dependabot: Bump caniuse-lite from 1.0.30001623 to 1.0.30001625
