### PR TITLE
combine all dependabot prs 2024 06 01 6466

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7186,14 +7186,14 @@
       }
     },
     "node_modules/@storybook/preact": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/@storybook/preact/-/preact-8.1.4.tgz",
-      "integrity": "sha512-+c4LK/Y0qXWbausmFi9S7sEhugL2gNVPoe4J6ZtdsdynqlIXPPmU04yyIRhP1f+QrdmiI9oxu1Xtxx2fZqEMpQ==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/preact/-/preact-8.1.5.tgz",
+      "integrity": "sha512-0wE878KLPB2s02VgIHm+n/5MhoIOmwvcv+lbOc4IPoFipx84PhnSrMm5WBLuGF7BT++yxjLiVKBVKYoLk2W1WA==",
       "dev": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
-        "@storybook/preview-api": "8.1.4",
-        "@storybook/types": "8.1.4",
+        "@storybook/preview-api": "8.1.5",
+        "@storybook/types": "8.1.5",
         "ts-dedent": "^2.0.0"
       },
       "engines": {
@@ -7339,13 +7339,13 @@
       }
     },
     "node_modules/@storybook/preact/node_modules/@storybook/channels": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-8.1.4.tgz",
-      "integrity": "sha512-cmITS0w8e9Ys1vqp8S7+uyQKgqVIdUEWs9FK90XeAs0lcuvW10S3qdrarWPbUgKFFFsGIGPIvImbT1vf80/bcQ==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-8.1.5.tgz",
+      "integrity": "sha512-R+puP4tWYzQUbpIp8sX6U5oI+ZUevVOaFxXGaAN3PRXjIRC38oKTVWzj/G6GdziVFzN6rDn+JsYPmiRMYo1sYg==",
       "dev": true,
       "dependencies": {
-        "@storybook/client-logger": "8.1.4",
-        "@storybook/core-events": "8.1.4",
+        "@storybook/client-logger": "8.1.5",
+        "@storybook/core-events": "8.1.5",
         "@storybook/global": "^5.0.0",
         "telejson": "^7.2.0",
         "tiny-invariant": "^1.3.1"
@@ -7356,9 +7356,9 @@
       }
     },
     "node_modules/@storybook/preact/node_modules/@storybook/client-logger": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-8.1.4.tgz",
-      "integrity": "sha512-I0PqDoNZf4rqrJYwFHhCwuXumpxvzyTzI5qI5R2JT93i49QShI3pLXY31C9VemVBJmS+pBWVOm6RTIdkQiKVWw==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-8.1.5.tgz",
+      "integrity": "sha512-zd+aENXnOHsxBATppELmhw/UywLzCxQjz/8i/xkUjeTRB4Ggp0hJlOUdJUEdIJz631ydyytfvM70ktBj9gMl1w==",
       "dev": true,
       "dependencies": {
         "@storybook/global": "^5.0.0"
@@ -7369,9 +7369,9 @@
       }
     },
     "node_modules/@storybook/preact/node_modules/@storybook/core-events": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-8.1.4.tgz",
-      "integrity": "sha512-oZAP3aRDeRyo2GQmADh4R3wJLIb9Ie0FUcWx8V4fvuydzeh6Pprgo//COCR+kySG4kRLqofWeF1Zzvft58Q0kg==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-8.1.5.tgz",
+      "integrity": "sha512-fgwbrHoLtSX6kfmamTGJqD+KfuEgun8cc4mWKZK094ByaqbSjhnOyeYO1sfVk8qst7QTFlOfhLAUe4cz1z149A==",
       "dev": true,
       "dependencies": {
         "@storybook/csf": "^0.1.7",
@@ -7383,17 +7383,17 @@
       }
     },
     "node_modules/@storybook/preact/node_modules/@storybook/preview-api": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/@storybook/preview-api/-/preview-api-8.1.4.tgz",
-      "integrity": "sha512-WHS3k/8UZT5vYJ+evSAMLG89sv1rBaojTQ2XNgv/DX74vK4l0MQ61wsORC0v7ScGyEuwYIuSCqHH5NNrOBLxmA==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/preview-api/-/preview-api-8.1.5.tgz",
+      "integrity": "sha512-pv0aT5WbnSYR7KWQgy3jLfuBM0ocYG6GTcmZLREW5554oiBPHhzNFv+ZrBI47RzbrbFxq1h5dj4v8lkEcKIrbA==",
       "dev": true,
       "dependencies": {
-        "@storybook/channels": "8.1.4",
-        "@storybook/client-logger": "8.1.4",
-        "@storybook/core-events": "8.1.4",
+        "@storybook/channels": "8.1.5",
+        "@storybook/client-logger": "8.1.5",
+        "@storybook/core-events": "8.1.5",
         "@storybook/csf": "^0.1.7",
         "@storybook/global": "^5.0.0",
-        "@storybook/types": "8.1.4",
+        "@storybook/types": "8.1.5",
         "@types/qs": "^6.9.5",
         "dequal": "^2.0.2",
         "lodash": "^4.17.21",
@@ -7409,12 +7409,12 @@
       }
     },
     "node_modules/@storybook/preact/node_modules/@storybook/types": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/@storybook/types/-/types-8.1.4.tgz",
-      "integrity": "sha512-QfTJg5Hu3c0eiD38Z75bZsw0iCIpruOTGV5O65vCpNun7D6WUyyMM0aUJN3ytujGiHfjsWVgiSe+WoHxdy/fEA==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/types/-/types-8.1.5.tgz",
+      "integrity": "sha512-/PfAZh1xtXN2MvAZZKpiL/nPkC3bZj8BQ7P7z5a/aQarP+y7qdXuoitYQ6oOH3rkaiYywmkWzA/y4iW70KXLKg==",
       "dev": true,
       "dependencies": {
-        "@storybook/channels": "8.1.4",
+        "@storybook/channels": "8.1.5",
         "@types/express": "^4.7.0",
         "file-system-cache": "2.3.0"
       },


### PR DESCRIPTION
- Dependabot: Bump electron-to-chromium from 1.4.783 to 1.4.786
- Dependabot: Bump @storybook/test from 8.1.4 to 8.1.5
- Dependabot: Bump @storybook/addon-links from 8.1.4 to 8.1.5
- Dependabot: Bump @storybook/blocks from 8.1.4 to 8.1.5
- Dependabot: Bump loader-utils from 3.2.1 to 3.2.2
- Dependabot: Bump @types/express-serve-static-core from 4.19.1 to 4.19.3
- Dependabot: Bump @storybook/preact from 8.1.4 to 8.1.5
