### PR TITLE
combine all dependabot prs 2024 06 04 3359

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11267,9 +11267,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.787",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.787.tgz",
-      "integrity": "sha512-d0EFmtLPjctczO3LogReyM2pbBiiZbnsKnGF+cdZhsYzHm/A0GV7W94kqzLD8SN4O3f3iHlgLUChqghgyznvCQ==",
+      "version": "1.4.788",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.788.tgz",
+      "integrity": "sha512-ubp5+Ev/VV8KuRoWnfP2QF2Bg+O2ZFdb49DiiNbz2VmgkIqrnyYaqIOqj8A6K/3p1xV0QcU5hBQ1+BmB6ot1OA==",
       "dev": true
     },
     "node_modules/emittery": {


### PR DESCRIPTION
- Dependabot: Bump recast from 0.23.7 to 0.23.9
- Dependabot: Bump preact-render-to-string from 6.5.3 to 6.5.4
- Dependabot: Bump array.prototype.tosorted from 1.1.3 to 1.1.4
- Dependabot: Bump caniuse-lite from 1.0.30001625 to 1.0.30001627
- Dependabot: Bump electron-to-chromium from 1.4.787 to 1.4.788
