### PR TITLE
combine all dependabot prs 2024 06 12 3774

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11105,9 +11105,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.796",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.796.tgz",
-      "integrity": "sha512-NglN/xprcM+SHD2XCli4oC6bWe6kHoytcyLKCWXmRL854F0qhPhaYgUswUsglnPxYaNQIg2uMY4BvaomIf3kLA==",
+      "version": "1.4.798",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.798.tgz",
+      "integrity": "sha512-by9J2CiM9KPGj9qfp5U4FcPSbXJG7FNzqnYaY4WLzX+v2PHieVGmnsA4dxfpGE3QEC7JofpPZmn7Vn1B9NR2+Q==",
       "dev": true
     },
     "node_modules/emittery": {


### PR DESCRIPTION
- Dependabot: Bump @testing-library/jest-dom from 6.4.5 to 6.4.6
- Dependabot: Bump electron-to-chromium from 1.4.796 to 1.4.798
