### PR TITLE
combine all dependabot prs 2024 06 13 3407

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18761,9 +18761,9 @@
       }
     },
     "node_modules/preact-render-to-string": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.5.4.tgz",
-      "integrity": "sha512-06s0E3cEMLoXQznmtJ/K/xbFs3uwo52Qpgf8lzbe+VbF/XzwJ0LxZGtVLZekhaEeC39+W1MEf05F4lUikzPnxA==",
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.5.5.tgz",
+      "integrity": "sha512-KiMFTKNTmT/ccE79BURR/r6XRc2I2TCTZ0MpeWqHW2XnllbeghXvwGsdAfF/MzMilUcTfODtSmMxgoRFL9TM5g==",
       "dev": true,
       "peer": true,
       "peerDependencies": {


### PR DESCRIPTION
- Dependabot: Bump electron-to-chromium from 1.4.799 to 1.4.802
- Dependabot: Bump caniuse-lite from 1.0.30001632 to 1.0.30001633
- Dependabot: Bump preact-render-to-string from 6.5.4 to 6.5.5
