### PR TITLE
combine all dependabot prs 2024 06 23 3410

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11882,9 +11882,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.806",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.806.tgz",
-      "integrity": "sha512-nkoEX2QIB8kwCOtvtgwhXWy2IHVcOLQZu9Qo36uaGB835mdX/h8uLRlosL6QIhLVUnAiicXRW00PwaPZC74Nrg==",
+      "version": "1.4.810",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.810.tgz",
+      "integrity": "sha512-Kaxhu4T7SJGpRQx99tq216gCq2nMxJo+uuT6uzz9l8TVN2stL7M06MIIXAtr9jsrLs2Glflgf2vMQRepxawOdQ==",
       "dev": true
     },
     "node_modules/emittery": {


### PR DESCRIPTION
- Dependabot: Bump @types/node from 18.19.38 to 18.19.39
- Dependabot: Bump electron-to-chromium from 1.4.806 to 1.4.810
