### PR TITLE
combine all dependabot prs 2024 06 26 5884

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13353,9 +13353,9 @@
       "dev": true
     },
     "node_modules/flow-parser": {
-      "version": "0.238.0",
-      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.238.0.tgz",
-      "integrity": "sha512-VE7XSv1epljsIN2YeBnxCmGJihpNIAnLLu/pPOdA+Gkso7qDltJwUi6vfHjgxdBbjSdAuPGnhuOHJUQG+yYwIg==",
+      "version": "0.238.2",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.238.2.tgz",
+      "integrity": "sha512-fs7FSnzzKF6oSzjk14JlBHt82DPchYHVsXtPi4Fkn+qrunVjWaBZY7nSO/mC9X4l9+wRah/R69DRd5NGDOrWqw==",
       "dev": true,
       "engines": {
         "node": ">=0.4.0"


### PR DESCRIPTION
- Dependabot: Bump object-inspect from 1.13.1 to 1.13.2
- Dependabot: Bump is-core-module from 2.13.1 to 2.14.0
- Dependabot: Bump @preact/preset-vite from 2.8.2 to 2.8.3
- Dependabot: Bump v8-to-istanbul from 9.2.0 to 9.3.0
- Dependabot: Bump @floating-ui/utils from 0.2.2 to 0.2.3
- Dependabot: Bump @floating-ui/react-dom from 2.1.0 to 2.1.1
- Dependabot: Bump marked from 13.0.0 to 13.0.1
- Dependabot: Bump @floating-ui/core from 1.6.2 to 1.6.3
- Dependabot: Bump @floating-ui/dom from 1.6.5 to 1.6.6
- Dependabot: Bump electron-to-chromium from 1.4.810 to 1.4.811
- Dependabot: Bump flow-parser from 0.238.0 to 0.238.2
