### PR TITLE
combine all dependabot prs 2024 06 27 2009

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11883,9 +11883,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.811",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.811.tgz",
-      "integrity": "sha512-CDyzcJ5XW78SHzsIOdn27z8J4ist8eaFLhdto2hSMSJQgsiwvbv2fbizcKUICryw1Wii1TI/FEkvzvJsR3awrA==",
+      "version": "1.4.812",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.812.tgz",
+      "integrity": "sha512-7L8fC2Ey/b6SePDFKR2zHAy4mbdp1/38Yk5TsARO66W3hC5KEaeKMMHoxwtuH+jcu2AYLSn9QX04i95t6Fl1Hg==",
       "dev": true
     },
     "node_modules/emittery": {


### PR DESCRIPTION
- Dependabot: Bump @prefresh/vite from 2.4.5 to 2.4.6
- Dependabot: Bump caniuse-lite from 1.0.30001636 to 1.0.30001637
- Dependabot: Bump electron-to-chromium from 1.4.811 to 1.4.812
