### PR TITLE
combine all dependabot prs 2024 06 29 5495

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8883,9 +8883,9 @@
       "dev": true
     },
     "node_modules/@types/lodash": {
-      "version": "4.17.5",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.5.tgz",
-      "integrity": "sha512-MBIOHVZqVqgfro1euRDWX7OO0fBVUUMrN6Pwm8LQsz8cWhEpihlvR70ENj3f40j58TNxZaWv2ndSkInykNBBJw==",
+      "version": "4.17.6",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.6.tgz",
+      "integrity": "sha512-OpXEVoCKSS3lQqjx9GGGOapBeuW5eUboYHRlHP9urXPX25IKZ6AnP5ZRxtVf63iieUbsHxLn8NQ5Nlftc6yzAA==",
       "dev": true
     },
     "node_modules/@types/mdx": {


### PR DESCRIPTION
- Dependabot: Bump vite from 5.3.1 to 5.3.2
- Dependabot: Bump @eslint-community/regexpp from 4.10.1 to 4.11.0
- Dependabot: Bump nypm from 0.3.8 to 0.3.9
- Dependabot: Bump @types/lodash from 4.17.5 to 4.17.6
