### PR TITLE
combine all dependabot prs 2024 07 02 6755

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10476,9 +10476,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001638",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001638.tgz",
-      "integrity": "sha512-5SuJUJ7cZnhPpeLHaH0c/HPAnAHZvS6ElWyHK9GSIbVOQABLzowiI2pjmpvZ1WEbkyz46iFd4UXlOHR5SqgfMQ==",
+      "version": "1.0.30001639",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001639.tgz",
+      "integrity": "sha512-eFHflNTBIlFwP2AIKaYuBQN/apnUoKNhBdza8ZnW/h2di4LCZ4xFqYlxUxo+LQ76KFI1PGcC1QDxMbxTZpSCAg==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
- Dependabot: Bump @floating-ui/dom from 1.6.6 to 1.6.7
- Dependabot: Bump electron-to-chromium from 1.4.812 to 1.4.815
- Dependabot: Bump postcss from 8.4.38 to 8.4.39
- Dependabot: Bump @floating-ui/core from 1.6.3 to 1.6.4
- Dependabot: Bump pkg-types from 1.1.1 to 1.1.2
- Dependabot: Bump unplugin from 1.10.1 to 1.11.0
- Dependabot: Bump flow-parser from 0.238.2 to 0.238.3
- Dependabot: Bump @floating-ui/utils from 0.2.3 to 0.2.4
- Dependabot: Bump preact from 10.22.0 to 10.22.1
- Dependabot: Bump caniuse-lite from 1.0.30001638 to 1.0.30001639
