### PR TITLE
combine all dependabot prs 2024 07 04 1210

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22171,9 +22171,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.16.tgz",
-      "integrity": "sha512-KVbTxlBYlckhF5wgfyZXTWnMn7MMZjMu9XG8bPlliUOP9ThaF4QnhP8qrjrH7DRzHfSk0oQv1wToW+iA5GajEQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
+      "integrity": "sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
- Dependabot: Bump caniuse-lite from 1.0.30001639 to 1.0.30001640
- Dependabot: Bump vite from 5.3.2 to 5.3.3
- Dependabot: Bump pkg-types from 1.1.2 to 1.1.3
- Dependabot: Bump acorn from 8.12.0 to 8.12.1
- Dependabot: Bump update-browserslist-db from 1.0.16 to 1.1.0
