### PR TITLE
combine all dependabot prs 2024 07 10 6008

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15024,15 +15024,15 @@
       }
     },
     "node_modules/jackspeak": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.1.tgz",
-      "integrity": "sha512-U23pQPDnmYybVkYjObcuYMk43VRlMLLqLI+RdZy8s8WV8WsxO9SnqSroKaluuvcNOdCAlauKszDwd+umbot5Mg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.2.tgz",
+      "integrity": "sha512-qH3nOSj8q/8+Eg8LUPOq3C+6HWkpUioIjDsq1+D4zY91oZvpPttw8GwtF1nReRYKXl+1AORyFqtm2f5Q1SB6/Q==",
       "dev": true,
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": "14 >=14.21 || 16 >=16.20 || >=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"


### PR DESCRIPTION
- Dependabot: Bump esquery from 1.5.0 to 1.6.0
- Dependabot: Bump electron-to-chromium from 1.4.818 to 1.4.820
- Dependabot: Bump flow-parser from 0.239.0 to 0.239.1
- Dependabot: Bump rollup from 4.18.0 to 4.18.1
- Dependabot: Bump jackspeak from 3.4.1 to 3.4.2
