### PR TITLE
combine all dependabot prs 2024 07 11 10270

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10476,9 +10476,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001640",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001640.tgz",
-      "integrity": "sha512-lA4VMpW0PSUrFnkmVuEKBUovSWKhj7puyCg8StBChgu298N1AtuF1sKWEvfDuimSEDbhlb/KqPKC3fs1HbuQUA==",
+      "version": "1.0.30001641",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001641.tgz",
+      "integrity": "sha512-Phv5thgl67bHYo1TtMY/MurjkHhV4EDaCosezRXgZ8jzA/Ub+wjxAvbGvjoFENStinwi5kCyOYV3mi5tOGykwA==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
- Dependabot: Bump electron-to-chromium from 1.4.820 to 1.4.823
- Dependabot: Bump @jridgewell/sourcemap-codec from 1.4.15 to 1.5.0
- Dependabot: Bump browserslist from 4.23.1 to 4.23.2
- Dependabot: Bump caniuse-lite from 1.0.30001640 to 1.0.30001641
