### PR TITLE
combine all dependabot prs 2024 07 13 5010

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -441,9 +441,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.7.tgz",
-      "integrity": "sha512-7MbVt6xrwFQbunH2DNQsAP5sTGxfqQtErvBIvIMi6EQnbgUOuVYanvREcmFrOPhoXBrTtjhhP+lW+o5UfK+tDg==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz",
+      "integrity": "sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"


### PR DESCRIPTION
- Dependabot: Bump nwsapi from 2.2.10 to 2.2.12
- Dependabot: Bump jackspeak from 3.4.2 to 3.4.3
- Dependabot: Bump @babel/plugin-transform-typeof-symbol
- Dependabot: Bump @babel/types from 7.24.7 to 7.24.8
- Dependabot: Bump @babel/helpers from 7.24.7 to 7.24.8
- Dependabot: Bump @babel/core from 7.24.7 to 7.24.8
- Dependabot: Bump @babel/helper-validator-option from 7.24.7 to 7.24.8
- Dependabot: Bump @babel/preset-env from 7.24.7 to 7.24.8
- Dependabot: Bump @babel/helper-create-class-features-plugin
- Dependabot: Bump @babel/helper-member-expression-to-functions
- Dependabot: Bump electron-to-chromium from 1.4.824 to 1.4.827
- Dependabot: Bump postcss-selector-parser from 6.1.0 to 6.1.1
- Dependabot: Bump @babel/plugin-transform-destructuring
- Dependabot: Bump @babel/parser from 7.24.7 to 7.24.8
- Dependabot: Bump @babel/helper-module-transforms from 7.24.7 to 7.24.8
- Dependabot: Bump @babel/plugin-transform-modules-commonjs
- Dependabot: Bump @babel/plugin-transform-classes from 7.24.7 to 7.24.8
- Dependabot: Bump @babel/compat-data from 7.24.7 to 7.24.8
- Dependabot: Bump @babel/plugin-transform-typescript
- Dependabot: Bump @babel/traverse from 7.24.7 to 7.24.8
- Dependabot: Bump @babel/plugin-transform-optional-chaining
- Dependabot: Bump @babel/generator from 7.24.7 to 7.24.8
- Dependabot: Bump @babel/runtime from 7.24.7 to 7.24.8
- Dependabot: Bump @babel/eslint-parser from 7.24.7 to 7.24.8
- Dependabot: Bump @babel/helper-compilation-targets from 7.24.7 to 7.24.8
- Dependabot: Bump @babel/helper-plugin-utils from 7.24.7 to 7.24.8
- Dependabot: Bump @preact/preset-vite from 2.8.3 to 2.9.0
- Dependabot: Bump @babel/helper-string-parser from 7.24.7 to 7.24.8
