### PR TITLE
combine all dependabot prs 2024 07 18 10047

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6655,9 +6655,9 @@
       }
     },
     "node_modules/@storybook/builder-vite/node_modules/@types/node": {
-      "version": "18.19.39",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.39.tgz",
-      "integrity": "sha512-nPwTRDKUctxw3di5b4TfT3I0sWDiWoPQCZjXhvdkINntwr8lcoVCKsTgnXeRubKIlfnV+eN/HYk6Jb40tbcEAQ==",
+      "version": "18.19.40",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.40.tgz",
+      "integrity": "sha512-MIxieZHrm4Ee8XArBIc+Or9HINt2StOmCbgRcXGSJl8q14svRvkZPe7LJq9HKtTI1SK3wU8b91TjntUm7T69Pg==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -7091,9 +7091,9 @@
       }
     },
     "node_modules/@storybook/core-common/node_modules/@types/node": {
-      "version": "18.19.39",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.39.tgz",
-      "integrity": "sha512-nPwTRDKUctxw3di5b4TfT3I0sWDiWoPQCZjXhvdkINntwr8lcoVCKsTgnXeRubKIlfnV+eN/HYk6Jb40tbcEAQ==",
+      "version": "18.19.40",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.40.tgz",
+      "integrity": "sha512-MIxieZHrm4Ee8XArBIc+Or9HINt2StOmCbgRcXGSJl8q14svRvkZPe7LJq9HKtTI1SK3wU8b91TjntUm7T69Pg==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -7218,9 +7218,9 @@
       }
     },
     "node_modules/@storybook/core-server/node_modules/@types/node": {
-      "version": "18.19.39",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.39.tgz",
-      "integrity": "sha512-nPwTRDKUctxw3di5b4TfT3I0sWDiWoPQCZjXhvdkINntwr8lcoVCKsTgnXeRubKIlfnV+eN/HYk6Jb40tbcEAQ==",
+      "version": "18.19.40",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.40.tgz",
+      "integrity": "sha512-MIxieZHrm4Ee8XArBIc+Or9HINt2StOmCbgRcXGSJl8q14svRvkZPe7LJq9HKtTI1SK3wU8b91TjntUm7T69Pg==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -8907,9 +8907,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.14.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.8.tgz",
-      "integrity": "sha512-DO+2/jZinXfROG7j7WKFn/3C6nFwxy2lLpgLjEXJz+0XKphZlTLJ14mo8Vfg8X5BWN6XjyESXq+LcYdT7tR3bA==",
+      "version": "20.14.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.11.tgz",
+      "integrity": "sha512-kprQpL8MMeszbz6ojB5/tU8PLN4kesnN8Gjzw349rDlNgsSzg90lAVj3llK99Dh7JON+t9AuscPPFW6mPbTnSA==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"


### PR DESCRIPTION
- Dependabot: Bump uglify-js from 3.18.0 to 3.19.0
- Dependabot: Bump preact-render-to-string from 6.5.5 to 6.5.6
- Dependabot: Bump flow-parser from 0.239.1 to 0.241.0
- Dependabot: Bump is-core-module from 2.14.0 to 2.15.0
- Dependabot: Bump @types/node from 18.19.39 to 18.19.40
