### PR TITLE
combine all dependabot prs 2024 07 22 7509

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10476,9 +10476,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001642",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001642.tgz",
-      "integrity": "sha512-3XQ0DoRgLijXJErLSl+bLnJ+Et4KqV1PY6JJBGAFlsNsz31zeAIncyeZfLCabHK/jtSh+671RM9YMldxjUPZtA==",
+      "version": "1.0.30001643",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001643.tgz",
+      "integrity": "sha512-ERgWGNleEilSrHM6iUz/zJNSQTP8Mr21wDWpdgvRwcTXGAq6jMtOUPP4dqFPTdKqZ2wKTdtB+uucZ3MRpAUSmg==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
- Dependabot: Bump node-releases from 2.0.17 to 2.0.18
- Dependabot: Bump rollup from 4.18.1 to 4.19.0
- Dependabot: Bump @emotion/use-insertion-effect-with-fallbacks
- Dependabot: Bump @floating-ui/core from 1.6.4 to 1.6.5
- Dependabot: Bump import-local from 3.1.0 to 3.2.0
- Dependabot: Bump @floating-ui/dom from 1.6.7 to 1.6.8
- Dependabot: Bump eslint-plugin-react from 7.34.4 to 7.35.0
- Dependabot: Bump @floating-ui/utils from 0.2.4 to 0.2.5
- Dependabot: Bump caniuse-lite from 1.0.30001642 to 1.0.30001643
