### PR TITLE
combine all dependabot prs 2024 07 24 7443

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6655,9 +6655,9 @@
       }
     },
     "node_modules/@storybook/builder-vite/node_modules/@types/node": {
-      "version": "18.19.41",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.41.tgz",
-      "integrity": "sha512-LX84pRJ+evD2e2nrgYCHObGWkiQJ1mL+meAgbvnwk/US6vmMY7S2ygBTGV2Jw91s9vUsLSXeDEkUHZIJGLrhsg==",
+      "version": "18.19.42",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.42.tgz",
+      "integrity": "sha512-d2ZFc/3lnK2YCYhos8iaNIYu9Vfhr92nHiyJHRltXWjXUBjEE+A4I58Tdbnw4VhggSW+2j5y5gTrLs4biNnubg==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -7091,9 +7091,9 @@
       }
     },
     "node_modules/@storybook/core-common/node_modules/@types/node": {
-      "version": "18.19.41",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.41.tgz",
-      "integrity": "sha512-LX84pRJ+evD2e2nrgYCHObGWkiQJ1mL+meAgbvnwk/US6vmMY7S2ygBTGV2Jw91s9vUsLSXeDEkUHZIJGLrhsg==",
+      "version": "18.19.42",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.42.tgz",
+      "integrity": "sha512-d2ZFc/3lnK2YCYhos8iaNIYu9Vfhr92nHiyJHRltXWjXUBjEE+A4I58Tdbnw4VhggSW+2j5y5gTrLs4biNnubg==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -7218,9 +7218,9 @@
       }
     },
     "node_modules/@storybook/core-server/node_modules/@types/node": {
-      "version": "18.19.41",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.41.tgz",
-      "integrity": "sha512-LX84pRJ+evD2e2nrgYCHObGWkiQJ1mL+meAgbvnwk/US6vmMY7S2ygBTGV2Jw91s9vUsLSXeDEkUHZIJGLrhsg==",
+      "version": "18.19.42",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.42.tgz",
+      "integrity": "sha512-d2ZFc/3lnK2YCYhos8iaNIYu9Vfhr92nHiyJHRltXWjXUBjEE+A4I58Tdbnw4VhggSW+2j5y5gTrLs4biNnubg==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -8907,9 +8907,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.14.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.11.tgz",
-      "integrity": "sha512-kprQpL8MMeszbz6ojB5/tU8PLN4kesnN8Gjzw349rDlNgsSzg90lAVj3llK99Dh7JON+t9AuscPPFW6mPbTnSA==",
+      "version": "20.14.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.12.tgz",
+      "integrity": "sha512-r7wNXakLeSsGT0H1AU863vS2wa5wBOK4bWMjZz2wj+8nBx+m5PeIn0k8AloSLpRuiwdRQZwarZqHE4FNArPuJQ==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"


### PR DESCRIPTION
- Dependabot: Bump typescript from 5.5.3 to 5.5.4
- Dependabot: Bump electron-to-chromium from 1.4.832 to 1.5.0
- Dependabot: Bump preact from 10.22.1 to 10.23.0
- Dependabot: Bump unplugin from 1.11.0 to 1.12.0
- Dependabot: Bump preact-render-to-string from 6.5.6 to 6.5.7
- Dependabot: Bump @types/node from 18.19.41 to 18.19.42
