### PR TITLE
combine all dependabot prs 2024 07 26 1267

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19471,9 +19471,9 @@
       "dev": true
     },
     "node_modules/preact": {
-      "version": "10.23.0",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.23.0.tgz",
-      "integrity": "sha512-Pox0jeY4q6PGkFB5AsXni+zHxxx/sAYFIFZzukW4nIpoJLRziRX0xC4WjZENlkSrDQvqVgZcaZzZ/NL8/A+H/w==",
+      "version": "10.23.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.23.1.tgz",
+      "integrity": "sha512-O5UdRsNh4vdZaTieWe3XOgSpdMAmkIYBCT3VhQDlKrzyCm8lUYsk0fmVEvoQQifoOjFRTaHZO69ylrzTW2BH+A==",
       "dev": true,
       "funding": {
         "type": "opencollective",


### PR DESCRIPTION
- Dependabot: Bump postcss from 8.4.39 to 8.4.40
- Dependabot: Bump electron-to-chromium from 1.5.0 to 1.5.1
- Dependabot: Bump vite from 5.3.4 to 5.3.5
- Dependabot: Bump preact from 10.23.0 to 10.23.1
