### PR TITLE
combine all dependabot prs 2024 07 27 2928

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12132,9 +12132,9 @@
       "dev": true
     },
     "node_modules/esbuild-register": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/esbuild-register/-/esbuild-register-3.5.0.tgz",
-      "integrity": "sha512-+4G/XmakeBAsvJuDugJvtyF1x+XJT4FMocynNpxrvEBViirpfUn2PgNpCHedfWhF4WokNsO/OvMKrmJOIJsI5A==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/esbuild-register/-/esbuild-register-3.6.0.tgz",
+      "integrity": "sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==",
       "dev": true,
       "dependencies": {
         "debug": "^4.3.4"


### PR DESCRIPTION
- Dependabot: Bump electron-to-chromium from 1.5.1 to 1.5.2
- Dependabot: Bump @storybook/icons from 1.2.9 to 1.2.10
- Dependabot: Bump chai from 4.4.1 to 4.5.0
- Dependabot: Bump esbuild-register from 3.5.0 to 3.6.0
