### PR TITLE
combine all dependabot prs 2024 07 30 9481

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -539,12 +539,12 @@
       }
     },
     "node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.24.7.tgz",
-      "integrity": "sha512-unaQgZ/iRu/By6tsjMZzpeBZjChYfLYry6HrEXPoz3KmfF0sVBQ1l8zKMQ4xRGLWVsjuvB8nQfjNP/DcfEOCsg==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.25.0.tgz",
+      "integrity": "sha512-lXwdNZtTmeVOOFtwM/WDe7yg1PL8sYhRk/XH0FzbR2HDQ0xC+EnQ/JHeoMYSavtU115tnUk0q9CDyq8si+LMAA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.24.8"
       },
       "engines": {
         "node": ">=6.9.0"


### PR DESCRIPTION
- Dependabot: Bump @babel/template from 7.24.7 to 7.25.0
- Dependabot: Bump @babel/generator from 7.24.10 to 7.25.0
- Dependabot: Bump marked from 13.0.2 to 13.0.3
- Dependabot: Bump @babel/plugin-transform-async-generator-functions
- Dependabot: Bump @babel/plugin-bugfix-v8-static-class-fields-redefine-readonly
- Dependabot: Bump @babel/helper-replace-supers from 7.24.7 to 7.25.0
- Dependabot: Bump @babel/runtime from 7.24.8 to 7.25.0
- Dependabot: Bump @babel/types from 7.24.9 to 7.25.0
- Dependabot: Bump @babel/compat-data from 7.24.9 to 7.25.0
- Dependabot: Bump @babel/parser from 7.24.8 to 7.25.0
- Dependabot: Bump @babel/helper-remap-async-to-generator
- Dependabot: Bump @babel/helper-wrap-function from 7.24.7 to 7.25.0
- Dependabot: Bump @babel/plugin-transform-modules-systemjs
- Dependabot: Bump @babel/eslint-parser from 7.24.8 to 7.25.1
- Dependabot: Bump @babel/plugin-transform-block-scoping
- Dependabot: Bump rollup from 4.19.0 to 4.19.1
- Dependabot: Bump @babel/plugin-transform-function-name
- Dependabot: Bump @babel/preset-env from 7.24.8 to 7.25.0
- Dependabot: Bump @babel/helper-create-regexp-features-plugin
- Dependabot: Bump @babel/helpers from 7.24.8 to 7.25.0
- Dependabot: Bump @babel/plugin-transform-typescript
- Dependabot: Bump @babel/traverse from 7.24.8 to 7.25.1
- Dependabot: Bump @babel/helper-create-class-features-plugin
- Dependabot: Bump @babel/helper-module-transforms from 7.24.9 to 7.25.0
- Dependabot: Bump @babel/plugin-transform-classes from 7.24.8 to 7.25.0
- Dependabot: Bump uglify-js from 3.19.0 to 3.19.1
- Dependabot: Bump @babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression
