### PR TITLE
combine all dependabot prs 2024 07 31 9871

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -263,31 +263,6 @@
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
     },
-    "node_modules/@babel/helper-environment-visitor": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.24.7.tgz",
-      "integrity": "sha512-DoiN84+4Gnd0ncbBOM9AZENV4a5ZiL39HYMyZJGZ/AZEykHYdJw0wW3kdcsh9/Kn+BRXHLkkklZ51ecPKmI1CQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.24.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-function-name": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.24.7.tgz",
-      "integrity": "sha512-FyoJTsj/PEUWu1/TYRiXTIHc8lbw+TDYkZuoE43opPS5TrI7MyONBE1oNvfguEXAD9yhQRrVBnXdXzSLQl9XnA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/template": "^7.24.7",
-        "@babel/types": "^7.24.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/helper-member-expression-to-functions": {
       "version": "7.24.8",
       "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.24.8.tgz",
@@ -407,18 +382,6 @@
       "dev": true,
       "dependencies": {
         "@babel/traverse": "^7.24.7",
-        "@babel/types": "^7.24.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.7.tgz",
-      "integrity": "sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==",
-      "dev": true,
-      "dependencies": {
         "@babel/types": "^7.24.7"
       },
       "engines": {
@@ -2156,9 +2119,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.0.tgz",
-      "integrity": "sha512-LcnxQSsd9aXOIgmmSpvZ/1yo46ra2ESYyqLcryaBZOghxy5qqOBjvCWP5JfkI8yl9rlxRgdLTTMCQQRcN2hdCg==",
+      "version": "7.25.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.2.tgz",
+      "integrity": "sha512-YTnYtra7W9e6/oAZEHj0bJehPRUlLH9/fbpT5LfB0NhQXyALCRkRs3zH9v07IYhkgpqX6Z78FnuccZr/l4Fs4Q==",
       "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.24.8",


### PR DESCRIPTION
- Dependabot: Bump @babel/plugin-transform-react-jsx from 7.24.7 to 7.25.2
- Dependabot: Bump @babel/core from 7.24.9 to 7.25.2
- Dependabot: Bump @babel/plugin-transform-typescript
- Dependabot: Bump which-builtin-type from 1.1.3 to 1.1.4
- Dependabot: Bump @babel/plugin-transform-literals from 7.24.7 to 7.25.2
- Dependabot: Bump @babel/preset-env from 7.25.0 to 7.25.2
- Dependabot: Bump @babel/helper-create-regexp-features-plugin
- Dependabot: Bump flow-parser from 0.241.0 to 0.242.1
- Dependabot: Bump @babel/plugin-transform-flow-strip-types
- Dependabot: Bump @babel/helper-compilation-targets from 7.24.8 to 7.25.2
- Dependabot: Bump @babel/traverse from 7.25.1 to 7.25.2
- Dependabot: Bump @babel/helper-module-transforms from 7.25.0 to 7.25.2
- Dependabot: Bump @babel/compat-data from 7.25.0 to 7.25.2
- Dependabot: Bump electron-to-chromium from 1.5.2 to 1.5.3
- Dependabot: Bump caniuse-lite from 1.0.30001643 to 1.0.30001644
- Dependabot: Bump @babel/types from 7.25.0 to 7.25.2
