### PR TITLE
combine all dependabot prs 2024 08 02 6641

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -458,10 +458,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.0.tgz",
-      "integrity": "sha512-CzdIU9jdP0dg7HdyB+bHvDJGagUv+qtzZt5rYCWwW6tITNqV9odjp6Qu41gkG0ca5UfdDUWrKkiAnHHdGRnOrA==",
+      "version": "7.25.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.3.tgz",
+      "integrity": "sha512-iLTJKDbJ4hMvFPgQwwsVoxtHyWpKKPBrxkANrSYewDPaPpT5py5yeVkgPIJ7XYXhndxJpaA3PyALSXQ7u8e/Dw==",
       "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.25.2"
+      },
       "bin": {
         "parser": "bin/babel-parser.js"
       },


### PR DESCRIPTION
- Dependabot: Bump @babel/plugin-bugfix-firefox-class-in-computed-class-key
- Dependabot: Bump rollup from 4.19.1 to 4.19.2
- Dependabot: Bump @babel/preset-env from 7.25.2 to 7.25.3
- Dependabot: Bump @babel/traverse from 7.25.2 to 7.25.3
- Dependabot: Bump caniuse-lite from 1.0.30001645 to 1.0.30001646
- Dependabot: Bump @babel/parser from 7.25.0 to 7.25.3
