### PR TITLE
combine all dependabot prs 2024 08 06 7196

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2690,9 +2690,9 @@
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.5.tgz",
-      "integrity": "sha512-sTcG+QZ6fdEUObICavU+aB3Mp8HY4n14wYHdxK4fXjPmv3PXZZeY5RaguJmGyeH/CJQhX3fqKUtS4qc1LoHwhQ==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.6.tgz",
+      "integrity": "sha512-0KI3zGxIUs1KDR/pjQPdJH4Z8nGBm0yJ5WRoRfdw1Kzeh45jkIfA0rmD0kBF6fKHH+xaH7g8y4jIXyAV5MGK3g==",
       "dev": true
     },
     "node_modules/@humanwhocodes/config-array": {


### PR DESCRIPTION
- Dependabot: Bump caniuse-lite from 1.0.30001646 to 1.0.30001649
- Dependabot: Bump rollup from 4.19.2 to 4.20.0
- Dependabot: Bump core-js from 3.37.1 to 3.38.0
- Dependabot: Bump babel-plugin-polyfill-corejs3 from 0.10.4 to 0.10.6
- Dependabot: Bump core-js-compat from 3.37.1 to 3.38.0
- Dependabot: Bump @floating-ui/dom from 1.6.8 to 1.6.9
- Dependabot: Bump @floating-ui/core from 1.6.5 to 1.6.6
- Dependabot: Bump postcss from 8.4.40 to 8.4.41
- Dependabot: Bump electron-to-chromium from 1.5.4 to 1.5.5
- Dependabot: Bump @floating-ui/utils from 0.2.5 to 0.2.6
