### PR TITLE
combine all dependabot prs 2024 08 08 2899

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2690,9 +2690,9 @@
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.6.tgz",
-      "integrity": "sha512-0KI3zGxIUs1KDR/pjQPdJH4Z8nGBm0yJ5WRoRfdw1Kzeh45jkIfA0rmD0kBF6fKHH+xaH7g8y4jIXyAV5MGK3g==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.7.tgz",
+      "integrity": "sha512-X8R8Oj771YRl/w+c1HqAC1szL8zWQRwFvgDwT129k9ACdBoud/+/rX9V0qiMl6LWUdP9voC2nDVZYPMQQsb6eA==",
       "dev": true
     },
     "node_modules/@humanwhocodes/config-array": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "fs": "^0.0.1-security",
         "jest": "^29.7.0",
         "jest-preset-preact": "^4.1.0",
-        "marked": "^13.0.0",
+        "marked": "^14.0.0",
         "preact": "^10.11.3",
         "prop-types": "^15.8.1",
         "rollup": "^4.9.2",
@@ -2658,22 +2658,22 @@
       "dev": true
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.6.tgz",
-      "integrity": "sha512-Vkvsw6EcpMHjvZZdMkSY+djMGFbt7CRssW99Ne8tar2WLnZ/l3dbxeTShbLQj+/s35h+Qb4cmnob+EzwtjrXGQ==",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.7.tgz",
+      "integrity": "sha512-yDzVT/Lm101nQ5TCVeK65LtdN7Tj4Qpr9RTXJ2vPFLqtLxwOrpoxAHAJI8J3yYWUc40J0BDBheaitK5SJmno2g==",
       "dev": true,
       "dependencies": {
-        "@floating-ui/utils": "^0.2.6"
+        "@floating-ui/utils": "^0.2.7"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.6.9",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.9.tgz",
-      "integrity": "sha512-zB1PcI350t4tkm3rvUhSRKa9sT7vH5CrAbQxW+VaPYJXKAO0gsg4CTueL+6Ajp7XzAQC8CW4Jj1Wgqc0sB6oUQ==",
+      "version": "1.6.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.10.tgz",
+      "integrity": "sha512-fskgCFv8J8OamCmyun8MfjB1Olfn+uZKjOKZ0vhYF3gRmEUXcGOjxWL8bBr7i4kIuPZ2KD2S3EUIOxnjC8kl2A==",
       "dev": true,
       "dependencies": {
         "@floating-ui/core": "^1.6.0",
-        "@floating-ui/utils": "^0.2.6"
+        "@floating-ui/utils": "^0.2.7"
       }
     },
     "node_modules/@floating-ui/react-dom": {
@@ -10449,9 +10449,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001649",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001649.tgz",
-      "integrity": "sha512-fJegqZZ0ZX8HOWr6rcafGr72+xcgJKI9oWfDW5DrD7ExUtgZC7a7R7ZYmZqplh7XDocFdGeIFn7roAxhOeYrPQ==",
+      "version": "1.0.30001651",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001651.tgz",
+      "integrity": "sha512-9Cf+Xv1jJNe1xPZLGuUXLNkE1BoDkqRqYyFJ9TDYSqhduqA4hu4oR9HluGoWYQC/aj8WHjsGVV+bwkh0+tegRg==",
       "dev": true,
       "funding": [
         {
@@ -13280,9 +13280,9 @@
       "dev": true
     },
     "node_modules/flow-parser": {
-      "version": "0.242.1",
-      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.242.1.tgz",
-      "integrity": "sha512-E3ml21Q1S5cMAyPbtYslkvI6yZO5oCS/S2EoteeFH8Kx9iKOv/YOJ+dGd/yMf+H3YKfhMKjnOpyNwrO7NdddWA==",
+      "version": "0.243.0",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.243.0.tgz",
+      "integrity": "sha512-HCDBfH+kZcY5etWYeAqatjW78gkIryzb9XixRsA8lGI1uyYc7aCpElkkO4H+KIpoyQMiY0VAZPI4cyac3wQe8w==",
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
@@ -13298,9 +13298,9 @@
       }
     },
     "node_modules/foreground-child": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.2.1.tgz",
-      "integrity": "sha512-PXUUyLqrR2XCWICfv6ukppP96sdFwWbNEnfEMt7jNsISjMsvaLNinAHNDYyvkyU+SZG2BTSbT5NjG+vZslfGTA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
+      "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
       "dev": true,
       "dependencies": {
         "cross-spawn": "^7.0.0",
@@ -17621,9 +17621,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "13.0.3",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-13.0.3.tgz",
-      "integrity": "sha512-rqRix3/TWzE9rIoFGIn8JmsVfhiuC8VIQ8IdX5TfzmeBucdY05/0UlzKaw0eVtpcN/OdVFpBk7CjKGo9iHJ/zA==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
+      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
       "dev": true,
       "bin": {
         "marked": "bin/marked.js"
@@ -22104,9 +22104,9 @@
       }
     },
     "node_modules/unplugin": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-1.12.0.tgz",
-      "integrity": "sha512-KeczzHl2sATPQUx1gzo+EnUkmN4VmGBYRRVOZSGvGITE9rGHRDGqft6ONceP3vgXcyJ2XjX5axG5jMWUwNCYLw==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-1.12.1.tgz",
+      "integrity": "sha512-aXEH9c5qi3uYZHo0niUtxDlT9ylG/luMW/dZslSCkbtC31wCyFkmM0kyoBBh+Grhn7CL+/kvKLfN61/EdxPxMQ==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.12.1",
@@ -22307,14 +22307,14 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.3.5.tgz",
-      "integrity": "sha512-MdjglKR6AQXQb9JGiS7Rc2wC6uMjcm7Go/NHNO63EwiJXfuk9PgqiP/n5IDJCziMkfw9n4Ubp7lttNwz+8ZVKA==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.0.tgz",
+      "integrity": "sha512-5xokfMX0PIiwCMCMb9ZJcMyh5wbBun0zUzKib+L65vAZ8GY9ePZMXxFrHbr/Kyll2+LSCY7xtERPpxkBDKngwg==",
       "dev": true,
       "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
-        "postcss": "^8.4.39",
+        "postcss": "^8.4.40",
         "rollup": "^4.13.0"
       },
       "bin": {
@@ -22334,6 +22334,7 @@
         "less": "*",
         "lightningcss": "^1.21.0",
         "sass": "*",
+        "sass-embedded": "*",
         "stylus": "*",
         "sugarss": "*",
         "terser": "^5.4.0"
@@ -22349,6 +22350,9 @@
           "optional": true
         },
         "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
           "optional": true
         },
         "stylus": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "fs": "^0.0.1-security",
     "jest": "^29.7.0",
     "jest-preset-preact": "^4.1.0",
-    "marked": "^13.0.0",
+    "marked": "^14.0.0",
     "preact": "^10.11.3",
     "prop-types": "^15.8.1",
     "rollup": "^4.9.2",


### PR DESCRIPTION
- Dependabot: Bump marked from 13.0.3 to 14.0.0
- Dependabot: Bump @floating-ui/core from 1.6.6 to 1.6.7
- Dependabot: Bump foreground-child from 3.2.1 to 3.3.0
- Dependabot: Bump vite from 5.3.5 to 5.4.0
- Dependabot: Bump @floating-ui/dom from 1.6.9 to 1.6.10
- Dependabot: Bump unplugin from 1.12.0 to 1.12.1
- Dependabot: Bump flow-parser from 0.242.1 to 0.243.0
- Dependabot: Bump caniuse-lite from 1.0.30001649 to 1.0.30001651
- Dependabot: Bump @floating-ui/utils from 0.2.6 to 0.2.7
