### PR TITLE
combine all dependabot prs 2024 08 13 5051

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14041,9 +14041,9 @@
       ]
     },
     "node_modules/ignore": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
-      "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
       "engines": {
         "node": ">= 4"


### PR DESCRIPTION
- Dependabot: Bump postcss-selector-parser from 6.1.1 to 6.1.2
- Dependabot: Bump uglify-js from 3.19.1 to 3.19.2
- Dependabot: Bump preact-render-to-string from 6.5.7 to 6.5.8
- Dependabot: Bump electron-to-chromium from 1.5.5 to 1.5.6
- Dependabot: Bump @types/node from 18.19.43 to 18.19.44
- Dependabot: Bump ignore from 5.3.1 to 5.3.2
