### PR TITLE
combine all dependabot prs 2024 08 18 4972

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22310,14 +22310,14 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.0.tgz",
-      "integrity": "sha512-5xokfMX0PIiwCMCMb9ZJcMyh5wbBun0zUzKib+L65vAZ8GY9ePZMXxFrHbr/Kyll2+LSCY7xtERPpxkBDKngwg==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.1.tgz",
+      "integrity": "sha512-1oE6yuNXssjrZdblI9AfBbHCC41nnyoVoEZxQnID6yvQZAFBzxxkqoFLtHUMkYunL8hwOLEjgTuxpkRxvba3kA==",
       "dev": true,
       "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
-        "postcss": "^8.4.40",
+        "postcss": "^8.4.41",
         "rollup": "^4.13.0"
       },
       "bin": {


### PR DESCRIPTION
- Dependabot: Bump preact-render-to-string from 6.5.8 to 6.5.9
- Dependabot: Bump @types/unist from 2.0.10 to 2.0.11
- Dependabot: Bump unplugin from 1.12.1 to 1.12.2
- Dependabot: Bump electron-to-chromium from 1.5.7 to 1.5.9
- Dependabot: Bump vite from 5.4.0 to 5.4.1
