### PR TITLE
combine all dependabot prs 2024 08 23 1767

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -154,12 +154,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.0.tgz",
-      "integrity": "sha512-3LEEcj3PVW8pW2R1SR1M89g/qrYk/m/mB/tLqn7dn4sbBUQyTqnlod+II2U4dqiGtUmkcnAmkMDralTFZttRiw==",
+      "version": "7.25.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.5.tgz",
+      "integrity": "sha512-abd43wyLfbWoxC6ahM8xTkqLpGB2iWBVyuKC9/srhFunCd1SDNrV1s72bBpK4hLj8KLzHBBcOblvLQZBNw9r3w==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.25.0",
+        "@babel/types": "^7.25.4",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^2.5.1"
@@ -2122,9 +2122,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.25.2",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.2.tgz",
-      "integrity": "sha512-YTnYtra7W9e6/oAZEHj0bJehPRUlLH9/fbpT5LfB0NhQXyALCRkRs3zH9v07IYhkgpqX6Z78FnuccZr/l4Fs4Q==",
+      "version": "7.25.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.4.tgz",
+      "integrity": "sha512-zQ1ijeeCXVEh+aNL0RlmkPkG8HUiDcU2pzQQFjtbntgAczRASFzj4H+6+bV+dy1ntKR14I/DypeuRG1uma98iQ==",
       "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.24.8",


### PR DESCRIPTION
- Dependabot: Bump async from 3.2.5 to 3.2.6
- Dependabot: Bump core-js-compat from 3.38.0 to 3.38.1
- Dependabot: Bump electron-to-chromium from 1.5.11 to 1.5.13
- Dependabot: Bump core-js from 3.38.0 to 3.38.1
- Dependabot: Bump spdx-license-ids from 3.0.18 to 3.0.20
- Dependabot: Bump @types/react from 18.3.3 to 18.3.4
- Dependabot: Bump vite from 5.4.1 to 5.4.2
- Dependabot: Bump @babel/parser from 7.25.3 to 7.25.4
- Dependabot: Bump @babel/types from 7.25.2 to 7.25.4
- Dependabot: Bump is-core-module from 2.15.0 to 2.15.1
- Dependabot: Bump @babel/plugin-transform-unicode-sets-regex
- Dependabot: Bump @babel/compat-data from 7.25.2 to 7.25.4
- Dependabot: Bump @babel/runtime from 7.25.0 to 7.25.4
- Dependabot: Bump @babel/plugin-syntax-typescript from 7.24.7 to 7.25.4
- Dependabot: Bump pkg-types from 1.1.3 to 1.2.0
- Dependabot: Bump @babel/generator from 7.25.0 to 7.25.5
