### PR TITLE
combine all dependabot prs 2024 08 27 8780

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10591,9 +10591,9 @@
       }
     },
     "node_modules/cjs-module-lexer": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.3.1.tgz",
-      "integrity": "sha512-a3KdPAANPbNE4ZUv9h6LckSl9zLsYOP4MBmhIPkRaeyybt+r4UghLvq+xw/YwUcC1gqylCkL4rdVs3Lwupjm4Q==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.0.tgz",
+      "integrity": "sha512-N1NGmowPlGBLsOZLPvm48StN04V4YvQRL0i6b7ctrVY3epjP/ct7hFLOItz6pDIvRjwpfPxi52a2UWV2ziir8g==",
       "dev": true
     },
     "node_modules/clean-stack": {


### PR DESCRIPTION
- Dependabot: Bump caniuse-lite from 1.0.30001651 to 1.0.30001653
- Dependabot: Bump marked from 14.0.0 to 14.1.0
- Dependabot: Bump @types/node from 18.19.45 to 18.19.46
- Dependabot: Bump micromatch from 4.0.7 to 4.0.8
- Dependabot: Bump nypm from 0.3.9 to 0.3.11
- Dependabot: Bump cjs-module-lexer from 1.3.1 to 1.4.0
