### PR TITLE
combine all dependabot prs 2024 08 31 8072

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21958,9 +21958,9 @@
       "dev": true
     },
     "node_modules/uglify-js": {
-      "version": "3.19.2",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.2.tgz",
-      "integrity": "sha512-S8KA6DDI47nQXJSi2ctQ629YzwOVs+bQML6DAtvy0wgNdpi+0ySpQK0g2pxBq2xfF2z3YCscu7NNA8nXT9PlIQ==",
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
       "dev": true,
       "optional": true,
       "bin": {


### PR DESCRIPTION
- Dependabot: Bump @types/node from 18.19.46 to 18.19.47
- Dependabot: Bump @babel/plugin-syntax-import-attributes
- Dependabot: Bump @babel/traverse from 7.25.4 to 7.25.6
- Dependabot: Bump @babel/helpers from 7.25.0 to 7.25.6
- Dependabot: Bump @babel/runtime from 7.25.4 to 7.25.6
- Dependabot: Bump @babel/types from 7.25.4 to 7.25.6
- Dependabot: Bump preact-render-to-string from 6.5.9 to 6.5.10
- Dependabot: Bump @babel/plugin-syntax-import-assertions
- Dependabot: Bump @babel/generator from 7.25.5 to 7.25.6
- Dependabot: Bump @babel/parser from 7.25.4 to 7.25.6
- Dependabot: Bump flow-parser from 0.244.0 to 0.245.0
- Dependabot: Bump caniuse-lite from 1.0.30001653 to 1.0.30001655
- Dependabot: Bump escalade from 3.1.2 to 3.2.0
- Dependabot: Bump rollup from 4.21.0 to 4.21.2
- Dependabot: Bump @types/react from 18.3.4 to 18.3.5
- Dependabot: Bump uglify-js from 3.19.2 to 3.19.3
