### PR TITLE
combine all dependabot prs 2024 09 04 7565

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12389,9 +12389,9 @@
       }
     },
     "node_modules/eslint-plugin-react": {
-      "version": "7.35.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.35.0.tgz",
-      "integrity": "sha512-v501SSMOWv8gerHkk+IIQBkcGRGrO2nfybfj5pLxuJNFTPxxA3PSryhXTK+9pNbtkggheDdsC0E9Q8CuPk6JKA==",
+      "version": "7.35.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.35.1.tgz",
+      "integrity": "sha512-B5ok2JgbaaWn/zXbKCGgKDNL2tsID3Pd/c/yvjcpsd9HQDwyYc/TQv3AZMmOvrJgCs3AnYNUHRCQEMMQAYJ7Yg==",
       "dev": true,
       "dependencies": {
         "array-includes": "^3.1.8",


### PR DESCRIPTION
- Dependabot: Bump picocolors from 1.0.1 to 1.1.0
- Dependabot: Bump eslint-plugin-react from 7.35.0 to 7.35.1
