### PR TITLE
combine all dependabot prs 2024 09 05 5807

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13247,9 +13247,9 @@
       "dev": true
     },
     "node_modules/flow-parser": {
-      "version": "0.245.0",
-      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.245.0.tgz",
-      "integrity": "sha512-xUBkkpIDfDZHAebnDEX65FCVitJUctab82KFmtP5SY4cGly1vbuYNe6Muyp0NLXrgmBChVdoC2T+3/RUHi4Mww==",
+      "version": "0.245.1",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.245.1.tgz",
+      "integrity": "sha512-KaVIjRdCY+APtxQijfV1c7GN1bofByIlR7E6omQLW0sghkA8hh8uufQOqTf3oAAVTExsSLafmdL/QwyvE/gdEg==",
       "dev": true,
       "engines": {
         "node": ">=0.4.0"


### PR DESCRIPTION
- Dependabot: Bump unplugin from 1.12.3 to 1.13.1
- Dependabot: Bump vite from 5.4.2 to 5.4.3
- Dependabot: Bump @types/node from 18.19.48 to 18.19.49
- Dependabot: Bump marked from 14.1.0 to 14.1.1
- Dependabot: Bump postcss from 8.4.44 to 8.4.45
- Dependabot: Bump flow-parser from 0.245.0 to 0.245.1
