### PR TITLE
combine all dependabot prs 2024 09 06 4057

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11791,9 +11791,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.13",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.13.tgz",
-      "integrity": "sha512-lbBcvtIJ4J6sS4tb5TLp1b4LyfCdMkwStzXPyAgVgTRAsep4bvrAGaBOP7ZJtQMNJpSQ9SqG4brWOroNaQtm7Q==",
+      "version": "1.5.14",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.14.tgz",
+      "integrity": "sha512-bEfPECb3fJ15eaDnu9LEJ2vPGD6W1vt7vZleSVyFhYuMIKm3vz/g9lt7IvEzgdwj58RjbPKUF2rXTCN/UW47tQ==",
       "dev": true
     },
     "node_modules/emittery": {


### PR DESCRIPTION
- Dependabot: Bump caniuse-lite from 1.0.30001655 to 1.0.30001657
- Dependabot: Bump flow-parser from 0.245.1 to 0.245.2
- Dependabot: Bump electron-to-chromium from 1.5.13 to 1.5.14
