### PR TITLE
combine all dependabot prs 2024 09 09 4621

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11791,9 +11791,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.15",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.15.tgz",
-      "integrity": "sha512-Z4rIDoImwEJW+YYKnPul4DzqsWVqYetYVN3XqDmRpgV0mjz0hYTaeeh+8/9CL1bk3AHYmF4freW/NTiVoXA2gA==",
+      "version": "1.5.18",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.18.tgz",
+      "integrity": "sha512-1OfuVACu+zKlmjsNdcJuVQuVE61sZOLbNM4JAQ1Rvh6EOj0/EUKhMJjRH73InPlXSh8HIJk1cVZ8pyOV/FMdUQ==",
       "dev": true
     },
     "node_modules/emittery": {


### PR DESCRIPTION
- Dependabot: Bump cjs-module-lexer from 1.4.0 to 1.4.1
- Dependabot: Bump marked from 14.1.1 to 14.1.2
- Dependabot: Bump source-map-js from 1.2.0 to 1.2.1
- Dependabot: Bump caniuse-lite from 1.0.30001657 to 1.0.30001659
- Dependabot: Bump acorn-walk from 8.3.3 to 8.3.4
- Dependabot: Bump electron-to-chromium from 1.5.15 to 1.5.18
