### PR TITLE
combine all dependabot prs 2024 09 11 3709

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21878,9 +21878,9 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
-      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
+      "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
       "dev": true,
       "peer": true,
       "bin": {


### PR DESCRIPTION
- Dependabot: Bump unplugin from 1.13.1 to 1.14.0
- Dependabot: Bump express from 4.19.2 to 4.20.0
- Dependabot: Bump caniuse-lite from 1.0.30001659 to 1.0.30001660
- Dependabot: Bump typescript from 5.5.4 to 5.6.2
