### PR TITLE
combine all dependabot prs 2024 09 14 9859

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11776,9 +11776,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.18",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.18.tgz",
-      "integrity": "sha512-1OfuVACu+zKlmjsNdcJuVQuVE61sZOLbNM4JAQ1Rvh6EOj0/EUKhMJjRH73InPlXSh8HIJk1cVZ8pyOV/FMdUQ==",
+      "version": "1.5.22",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.22.tgz",
+      "integrity": "sha512-tKYm5YHPU1djz0O+CGJ+oJIvimtsCcwR2Z9w7Skh08lUdyzXY5djods3q+z2JkWdb7tCcmM//eVavSRAiaPRNg==",
       "dev": true
     },
     "node_modules/emittery": {


### PR DESCRIPTION
- Dependabot: Bump unicode-canonical-property-names-ecmascript
- Dependabot: Bump express from 4.20.0 to 4.21.0
- Dependabot: Bump unicode-match-property-value-ecmascript
- Dependabot: Bump regenerate-unicode-properties from 10.1.1 to 10.2.0
- Dependabot: Bump rollup from 4.21.2 to 4.21.3
- Dependabot: Bump eslint-plugin-compat from 6.0.0 to 6.0.1
- Dependabot: Bump envinfo from 7.13.0 to 7.14.0
- Dependabot: Bump vite from 5.4.3 to 5.4.5
- Dependabot: Bump eslint-plugin-react from 7.35.2 to 7.36.1
- Dependabot: Bump electron-to-chromium from 1.5.18 to 1.5.22
