### PR TITLE
combine all dependabot prs 2024 09 17 10870

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2658,12 +2658,12 @@
       "dev": true
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.7.tgz",
-      "integrity": "sha512-yDzVT/Lm101nQ5TCVeK65LtdN7Tj4Qpr9RTXJ2vPFLqtLxwOrpoxAHAJI8J3yYWUc40J0BDBheaitK5SJmno2g==",
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.8.tgz",
+      "integrity": "sha512-7XJ9cPU+yI2QeLS+FCSlqNFZJq8arvswefkZrYI1yQBbftw6FyrZOxYSh+9S7z7TpeWlRt9zJ5IhM1WIL334jA==",
       "dev": true,
       "dependencies": {
-        "@floating-ui/utils": "^0.2.7"
+        "@floating-ui/utils": "^0.2.8"
       }
     },
     "node_modules/@floating-ui/dom": {
@@ -2690,9 +2690,9 @@
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.7.tgz",
-      "integrity": "sha512-X8R8Oj771YRl/w+c1HqAC1szL8zWQRwFvgDwT129k9ACdBoud/+/rX9V0qiMl6LWUdP9voC2nDVZYPMQQsb6eA==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.8.tgz",
+      "integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==",
       "dev": true
     },
     "node_modules/@humanwhocodes/config-array": {


### PR DESCRIPTION
- Dependabot: Bump preact-render-to-string from 6.5.10 to 6.5.11
- Dependabot: Bump @eslint-community/regexpp from 4.11.0 to 4.11.1
- Dependabot: Bump flow-parser from 0.245.2 to 0.246.0
- Dependabot: Bump @floating-ui/utils from 0.2.7 to 0.2.8
- Dependabot: Bump @preact/preset-vite from 2.9.0 to 2.9.1
- Dependabot: Bump @floating-ui/dom from 1.6.10 to 1.6.11
- Dependabot: Bump preact from 10.23.2 to 10.24.0
- Dependabot: Bump @types/react from 18.3.5 to 18.3.6
- Dependabot: Bump postcss from 8.4.45 to 8.4.47
- Dependabot: Bump @types/qs from 6.9.15 to 6.9.16
- Dependabot: Bump @floating-ui/react-dom from 2.1.1 to 2.1.2
- Dependabot: Bump ohash from 1.1.3 to 1.1.4
- Dependabot: Bump @floating-ui/core from 1.6.7 to 1.6.8
