### PR TITLE
combine all dependabot prs 2024 09 18 4262

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8940,9 +8940,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "18.3.6",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.6.tgz",
-      "integrity": "sha512-CnGaRYNu2iZlkGXGrOYtdg5mLK8neySj0woZ4e2wF/eli2E6Sazmq5X+Nrj6OBrrFVQfJWTUFeqAzoRhWQXYvg==",
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.7.tgz",
+      "integrity": "sha512-KUnDCJF5+AiZd8owLIeVHqmW9yM4sqmDVf2JRJiBMFkGvkoZ4/WyV2lL4zVsoinmRS/W3FeEdZLEWFRofnT2FQ==",
       "dev": true,
       "dependencies": {
         "@types/prop-types": "*",


### PR DESCRIPTION
- Dependabot: Bump @types/prop-types from 15.7.12 to 15.7.13
- Dependabot: Bump electron-to-chromium from 1.5.23 to 1.5.24
- Dependabot: Bump vite from 5.4.5 to 5.4.6
- Dependabot: Bump @types/react from 18.3.6 to 18.3.7
