### PR TITLE
combine all dependabot prs 2024 09 24 4613

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10424,9 +10424,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001662",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001662.tgz",
-      "integrity": "sha512-sgMUVwLmGseH8ZIrm1d51UbrhqMCH3jvS7gF/M6byuHOnKyLOBL7W8yz5V02OHwgLGA36o/AFhWzzh4uc5aqTA==",
+      "version": "1.0.30001663",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001663.tgz",
+      "integrity": "sha512-o9C3X27GLKbLeTYZ6HBOLU1tsAcBZsLis28wrVzddShCS16RujjHp9GDHKZqrB3meE0YjhawvMFsGb/igqiPzA==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
- Dependabot: Bump @rollup/plugin-alias from 5.1.0 to 5.1.1
- Dependabot: Bump @rollup/plugin-node-resolve from 15.2.3 to 15.2.4
- Dependabot: Bump vite from 5.4.6 to 5.4.7
- Dependabot: Bump caniuse-lite from 1.0.30001662 to 1.0.30001663
