### PR TITLE
combine all dependabot prs 2024 09 26 2081

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6678,9 +6678,9 @@
       }
     },
     "node_modules/@storybook/builder-vite/node_modules/@types/node": {
-      "version": "18.19.50",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.50.tgz",
-      "integrity": "sha512-xonK+NRrMBRtkL1hVCc3G+uXtjh1Al4opBLjqVmipe5ZAaBYWW6cNAiBVZ1BvmkBhep698rP3UM3aRAdSALuhg==",
+      "version": "18.19.51",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.51.tgz",
+      "integrity": "sha512-IIMkWEIVQDlBpi6pPeGqTqOx7KbzGC3EgIyH8NrxplXOwWw0uVl9vthJUMFrxD7kcEfcRp7jIkgpB28M6JnfWA==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -7126,9 +7126,9 @@
       }
     },
     "node_modules/@storybook/core-common/node_modules/@types/node": {
-      "version": "18.19.50",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.50.tgz",
-      "integrity": "sha512-xonK+NRrMBRtkL1hVCc3G+uXtjh1Al4opBLjqVmipe5ZAaBYWW6cNAiBVZ1BvmkBhep698rP3UM3aRAdSALuhg==",
+      "version": "18.19.51",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.51.tgz",
+      "integrity": "sha512-IIMkWEIVQDlBpi6pPeGqTqOx7KbzGC3EgIyH8NrxplXOwWw0uVl9vthJUMFrxD7kcEfcRp7jIkgpB28M6JnfWA==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -7265,9 +7265,9 @@
       }
     },
     "node_modules/@storybook/core-server/node_modules/@types/node": {
-      "version": "18.19.50",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.50.tgz",
-      "integrity": "sha512-xonK+NRrMBRtkL1hVCc3G+uXtjh1Al4opBLjqVmipe5ZAaBYWW6cNAiBVZ1BvmkBhep698rP3UM3aRAdSALuhg==",
+      "version": "18.19.51",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.51.tgz",
+      "integrity": "sha512-IIMkWEIVQDlBpi6pPeGqTqOx7KbzGC3EgIyH8NrxplXOwWw0uVl9vthJUMFrxD7kcEfcRp7jIkgpB28M6JnfWA==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -8966,9 +8966,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "22.5.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.4.tgz",
-      "integrity": "sha512-FDuKUJQm/ju9fT/SeX/6+gBzoPzlVCzfzmGkwKvRHQVxi4BntVbyIwf6a4Xn62mrvndLiml6z/UBXIdEVjQLXg==",
+      "version": "22.7.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.0.tgz",
+      "integrity": "sha512-MOdOibwBs6KW1vfqz2uKMlxq5xAfAZ98SZjO8e3XnAbFnTJtAspqhWk7hrdSAs9/Y14ZWMiy7/MxMUzAOadYEw==",
       "dev": true,
       "dependencies": {
         "undici-types": "~6.19.2"


### PR DESCRIPTION
- Dependabot: Bump preact from 10.24.0 to 10.24.1
- Dependabot: Bump browserslist from 4.23.3 to 4.24.0
- Dependabot: Bump vite from 5.4.7 to 5.4.8
- Dependabot: Bump @types/react from 18.3.8 to 18.3.9
- Dependabot: Bump @types/node from 18.19.50 to 18.19.51
