### PR TITLE
combine all dependabot prs 2024 09 27 8194

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8868,9 +8868,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.19.5",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.5.tgz",
-      "integrity": "sha512-y6W03tvrACO72aijJ5uF02FRq5cgDR9lUxddQ8vyF+GvmjJQqbzDcJngEjURc+ZsG31VI3hODNZJ2URj86pzmg==",
+      "version": "4.19.6",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
+      "integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",


### PR DESCRIPTION
- Dependabot: Bump caniuse-lite from 1.0.30001663 to 1.0.30001664
- Dependabot: Bump nypm from 0.3.11 to 0.3.12
- Dependabot: Bump electron-to-chromium from 1.5.28 to 1.5.29
- Dependabot: Bump @types/express-serve-static-core from 4.19.5 to 4.19.6
