### PR TITLE
combine all dependabot prs 2024 09 28 3551

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21762,9 +21762,9 @@
       }
     },
     "node_modules/tocbot": {
-      "version": "4.29.0",
-      "resolved": "https://registry.npmjs.org/tocbot/-/tocbot-4.29.0.tgz",
-      "integrity": "sha512-E+8+lceJpWHJYKq+qFHbi+gmFdXZeOAliHFdgiIAUo68cr8ClReXAx7h9e3TcDM0kw9PSnBn3GAZEpRmRLZ93g==",
+      "version": "4.30.0",
+      "resolved": "https://registry.npmjs.org/tocbot/-/tocbot-4.30.0.tgz",
+      "integrity": "sha512-c0ucneDHP5zqsbczYxjRj1SWD+6EeD1mUbQPTdVJzNe0aAZH4NyeZt4cQQBjWU4v8tTlJtzDzEgD03sCc5nL1w==",
       "dev": true
     },
     "node_modules/toidentifier": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "eslint-config-google": "^0.14.0",
         "eslint-plugin-compat": "^6.0.0",
         "eslint-plugin-preact": "^0.1.0",
-        "eslint-plugin-storybook": "^0.8.0",
+        "eslint-plugin-storybook": "^0.9.0",
         "fs": "^0.0.1-security",
         "jest": "^29.7.0",
         "jest-preset-preact": "^4.1.0",
@@ -12454,9 +12454,9 @@
       }
     },
     "node_modules/eslint-plugin-react": {
-      "version": "7.36.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.36.1.tgz",
-      "integrity": "sha512-/qwbqNXZoq+VP30s1d4Nc1C5GTxjJQjk4Jzs4Wq2qzxFM7dSmuG2UkIjg2USMLh3A/aVcUNrK7v0J5U1XEGGwA==",
+      "version": "7.37.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.0.tgz",
+      "integrity": "sha512-IHBePmfWH5lKhJnJ7WB1V+v/GolbB0rjS8XYVCSQCZKaQCAUhMoVoOEn1Ef8Z8Wf0a7l8KTJvuZg5/e4qrZ6nA==",
       "dev": true,
       "dependencies": {
         "array-includes": "^3.1.8",
@@ -12515,9 +12515,9 @@
       }
     },
     "node_modules/eslint-plugin-storybook": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-storybook/-/eslint-plugin-storybook-0.8.0.tgz",
-      "integrity": "sha512-CZeVO5EzmPY7qghO2t64oaFM+8FTaD4uzOEjHKp516exyTKo+skKAL9GI3QALS2BXhyALJjNtwbmr1XinGE8bA==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-storybook/-/eslint-plugin-storybook-0.9.0.tgz",
+      "integrity": "sha512-qOT/2vQBo0VqrG/BhZv8IdSsKQiyzJw+2Wqq+WFCiblI/PfxLSrGkF/buiXF+HumwfsCyBdaC94UhqhmYFmAvA==",
       "dev": true,
       "dependencies": {
         "@storybook/csf": "^0.0.1",
@@ -13329,9 +13329,9 @@
       "dev": true
     },
     "node_modules/flow-parser": {
-      "version": "0.246.0",
-      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.246.0.tgz",
-      "integrity": "sha512-WHRizzSrWFTcKo7cVcbP3wzZVhzsoYxoWqbnH4z+JXGqrjVmnsld6kBZWVlB200PwD5ur8r+HV3KUDxv3cHhOQ==",
+      "version": "0.247.0",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.247.0.tgz",
+      "integrity": "sha512-IY9JLxkKPY4BNODrwaMycusCtIrB17QRnKIBlf36dgyv7jFUIefGaUsEBT0xG6xT/rxgrZAGEgqmQ25RNghhyg==",
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
@@ -22182,9 +22182,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
-      "integrity": "sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
+      "integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
       "dev": true,
       "funding": [
         {
@@ -22201,8 +22201,8 @@
         }
       ],
       "dependencies": {
-        "escalade": "^3.1.2",
-        "picocolors": "^1.0.1"
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.0"
       },
       "bin": {
         "update-browserslist-db": "cli.js"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "eslint-config-google": "^0.14.0",
     "eslint-plugin-compat": "^6.0.0",
     "eslint-plugin-preact": "^0.1.0",
-    "eslint-plugin-storybook": "^0.8.0",
+    "eslint-plugin-storybook": "^0.9.0",
     "fs": "^0.0.1-security",
     "jest": "^29.7.0",
     "jest-preset-preact": "^4.1.0",


### PR DESCRIPTION
- Dependabot: Bump eslint-plugin-storybook from 0.8.0 to 0.9.0
- Dependabot: Bump flow-parser from 0.246.0 to 0.247.0
- Dependabot: Bump eslint-plugin-react from 7.36.1 to 7.37.0
- Dependabot: Bump update-browserslist-db from 1.1.0 to 1.1.1
- Dependabot: Bump tocbot from 4.29.0 to 4.30.0
