### PR TITLE
combine all dependabot prs 2024 10 07 2186

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11856,9 +11856,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.29",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.29.tgz",
-      "integrity": "sha512-PF8n2AlIhCKXQ+gTpiJi0VhcHDb69kYX4MtCiivctc2QD3XuNZ/XIOlbGzt7WAjjEev0TtaH6Cu3arZExm5DOw==",
+      "version": "1.5.32",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.32.tgz",
+      "integrity": "sha512-M+7ph0VGBQqqpTT2YrabjNKSQ2fEl9PVx6AK3N558gDH9NO8O6XN9SXXFWRo9u9PbEg/bWq+tjXQr+eXmxubCw==",
       "dev": true
     },
     "node_modules/emittery": {


### PR DESCRIPTION
- Dependabot: Bump @babel/plugin-transform-classes from 7.25.4 to 7.25.7
- Dependabot: Bump @babel/helper-validator-identifier
- Dependabot: Bump @babel/plugin-transform-private-methods
- Dependabot: Bump @babel/plugin-transform-computed-properties
- Dependabot: Bump @babel/plugin-transform-class-properties
- Dependabot: Bump @babel/plugin-transform-logical-assignment-operators
- Dependabot: Bump @babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining
- Dependabot: Bump @babel/plugin-transform-modules-commonjs
- Dependabot: Bump @babel/helper-create-regexp-features-plugin
- Dependabot: Bump @babel/plugin-transform-nullish-coalescing-operator
- Dependabot: Bump @babel/helper-validator-option from 7.24.8 to 7.25.7
- Dependabot: Bump @babel/compat-data from 7.25.4 to 7.25.7
- Dependabot: Bump @babel/plugin-transform-unicode-regex
- Dependabot: Bump @babel/plugin-bugfix-firefox-class-in-computed-class-key
- Dependabot: Bump @babel/plugin-transform-object-rest-spread
- Dependabot: Bump @babel/plugin-transform-react-display-name
- Dependabot: Bump @babel/plugin-transform-modules-umd
- Dependabot: Bump @babel/helper-replace-supers from 7.25.0 to 7.25.7
- Dependabot: Bump @babel/highlight from 7.24.7 to 7.25.7
- Dependabot: Bump @babel/plugin-transform-unicode-sets-regex
- Dependabot: Bump @babel/plugin-syntax-jsx from 7.24.7 to 7.25.7
- Dependabot: Bump @babel/traverse from 7.25.6 to 7.25.7
- Dependabot: Bump @babel/helpers from 7.25.6 to 7.25.7
- Dependabot: Bump @babel/plugin-transform-react-pure-annotations
- Dependabot: Bump @babel/plugin-transform-block-scoping
- Dependabot: Bump @babel/plugin-transform-private-property-in-object
- Dependabot: Bump @babel/plugin-transform-exponentiation-operator
- Dependabot: Bump @babel/plugin-transform-reserved-words
- Dependabot: Bump caniuse-lite from 1.0.30001664 to 1.0.30001667
- Dependabot: Bump electron-to-chromium from 1.5.29 to 1.5.32
