### PR TITLE
combine all dependabot prs 2024 10 10 1660

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11850,9 +11850,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.32",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.32.tgz",
-      "integrity": "sha512-M+7ph0VGBQqqpTT2YrabjNKSQ2fEl9PVx6AK3N558gDH9NO8O6XN9SXXFWRo9u9PbEg/bWq+tjXQr+eXmxubCw==",
+      "version": "1.5.34",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.34.tgz",
+      "integrity": "sha512-/TZAiChbAflBNjCg+VvstbcwAtIL/VdMFO3NgRFIzBjpvPzWOTIbbO8kNb6RwU4bt9TP7K+3KqBKw/lOU+Y+GA==",
       "dev": true
     },
     "node_modules/emittery": {


### PR DESCRIPTION
- Dependabot: Bump @babel/preset-env from 7.25.4 to 7.25.7
- Dependabot: Bump regjsparser from 0.11.0 to 0.11.1
- Dependabot: Bump @babel/plugin-transform-for-of from 7.24.7 to 7.25.7
- Dependabot: Bump @babel/plugin-transform-async-to-generator
- Dependabot: Bump @babel/register from 7.24.6 to 7.25.7
- Dependabot: Bump @babel/plugin-transform-typeof-symbol
- Dependabot: Bump preact from 10.24.1 to 10.24.2
- Dependabot: Bump @babel/plugin-transform-dotall-regex
- Dependabot: Bump mlly from 1.7.1 to 1.7.2
- Dependabot: Bump @babel/plugin-transform-named-capturing-groups-regex
- Dependabot: Bump confbox from 0.1.7 to 0.1.8
- Dependabot: Bump pkg-types from 1.2.0 to 1.2.1
- Dependabot: Bump iterator.prototype from 1.1.2 to 1.1.3
- Dependabot: Bump @types/node from 18.19.54 to 18.19.55
- Dependabot: Bump es-iterator-helpers from 1.0.19 to 1.1.0
- Dependabot: Bump typescript from 5.6.2 to 5.6.3
- Dependabot: Bump express from 4.21.0 to 4.21.1
- Dependabot: Bump electron-to-chromium from 1.5.32 to 1.5.34
