### PR TITLE
combine all dependabot prs 2024 10 14 1378

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19513,9 +19513,9 @@
       "dev": true
     },
     "node_modules/preact": {
-      "version": "10.24.2",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.2.tgz",
-      "integrity": "sha512-1cSoF0aCC8uaARATfrlz4VCBqE8LwZwRfLgkxJOQwAlQt6ayTmi0D9OF7nXid1POI5SZidFuG9CnlXbDfLqY/Q==",
+      "version": "10.24.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
+      "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
       "dev": true,
       "funding": {
         "type": "opencollective",

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "rollup": "^4.9.2",
         "rollup-plugin-postcss": "^4.0.2",
         "rollup-plugin-visualizer": "^5.12.0",
-        "sirv-cli": "^2.0.2",
+        "sirv-cli": "^3.0.0",
         "storybook": "^7.6.6",
         "storybook-css-modules": "^1.0.8"
       },
@@ -97,18 +97,18 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.7.tgz",
-      "integrity": "sha512-9ickoLz+hcXCeh7jrcin+/SLWm+GkxE2kTvoYyp38p4WkdFXfQJxDFGWp/YHjiKLPx06z2A7W8XKuqbReXDzsw==",
+      "version": "7.25.8",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.8.tgz",
+      "integrity": "sha512-ZsysZyXY4Tlx+Q53XdnOFmqwfB9QDTHYxaZYajWRoBLuLEAwI2UIbtxOjWh/cFaa9IKUlcB+DDuoskLuKu56JA==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.7.tgz",
-      "integrity": "sha512-yJ474Zv3cwiSOO9nXJuqzvwEeM+chDuQ8GJirw+pZ91sCGCyOZ3dJkVE09fTV0VEVzXyLWhh3G/AolYTPX7Mow==",
+      "version": "7.25.8",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.8.tgz",
+      "integrity": "sha512-Oixnb+DzmRT30qu9d3tJSQkxuygWm32DFykT4bRoORPa9hZ/L4KhVB/XiRm6KG+roIEM7DBQlmg27kw2HZkdZg==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
@@ -117,10 +117,10 @@
         "@babel/helper-compilation-targets": "^7.25.7",
         "@babel/helper-module-transforms": "^7.25.7",
         "@babel/helpers": "^7.25.7",
-        "@babel/parser": "^7.25.7",
+        "@babel/parser": "^7.25.8",
         "@babel/template": "^7.25.7",
         "@babel/traverse": "^7.25.7",
-        "@babel/types": "^7.25.7",
+        "@babel/types": "^7.25.8",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -136,9 +136,9 @@
       }
     },
     "node_modules/@babel/eslint-parser": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.25.7.tgz",
-      "integrity": "sha512-B+BO9x86VYsQHimucBAL1fxTJKF4wyKY6ZVzee9QgzdZOUfs3BaR6AQrgoGrRI+7IFS1wUz/VyQ+SoBcSpdPbw==",
+      "version": "7.25.8",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.25.8.tgz",
+      "integrity": "sha512-Po3VLMN7fJtv0nsOjBDSbO1J71UhzShE9MuOSkWEV9IZQXzhZklYtzKZ8ZD/Ij3a0JBv1AG3Ny2L3jvAHQVOGg==",
       "dev": true,
       "dependencies": {
         "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
@@ -458,12 +458,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.7.tgz",
-      "integrity": "sha512-aZn7ETtQsjjGG5HruveUK06cU3Hljuhd9Iojm4M8WWv3wLE6OkE5PWbDUkItmMgegmccaITudyuW5RPYrYlgWw==",
+      "version": "7.25.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.8.tgz",
+      "integrity": "sha512-HcttkxzdPucv3nNFmfOOMfFf64KgdJVqm1KaCm25dPGMLElo9nsLvXeJECQg8UzPuBGLyTSA0ZzqCtDSzKTEoQ==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.25.7"
+        "@babel/types": "^7.25.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -626,30 +626,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-dynamic-import": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
-      "integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-export-namespace-from": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.8.3.tgz",
-      "integrity": "sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.3"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
@@ -888,14 +864,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-async-generator-functions": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.25.7.tgz",
-      "integrity": "sha512-4B6OhTrwYKHYYgcwErvZjbmH9X5TxQBsaBHdzEIB4l71gR5jh/tuHGlb9in47udL2+wVUcOz5XXhhfhVJwEpEg==",
+      "version": "7.25.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.25.8.tgz",
+      "integrity": "sha512-9ypqkozyzpG+HxlH4o4gdctalFGIjjdufzo7I2XPda0iBnZ6a+FO0rIEQcdSPXp02CkvGsII1exJhmROPQd5oA==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.7",
         "@babel/helper-remap-async-to-generator": "^7.25.7",
-        "@babel/plugin-syntax-async-generators": "^7.8.4",
         "@babel/traverse": "^7.25.7"
       },
       "engines": {
@@ -969,14 +944,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-class-static-block": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.25.7.tgz",
-      "integrity": "sha512-rvUUtoVlkDWtDWxGAiiQj0aNktTPn3eFynBcMC2IhsXweehwgdI9ODe+XjWw515kEmv22sSOTp/rxIRuTiB7zg==",
+      "version": "7.25.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.25.8.tgz",
+      "integrity": "sha512-e82gl3TCorath6YLf9xUwFehVvjvfqFhdOo4+0iVIVju+6XOi5XHkqB3P2AXnSwoeTX0HBoXq5gJFtvotJzFnQ==",
       "dev": true,
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.25.7",
-        "@babel/helper-plugin-utils": "^7.25.7",
-        "@babel/plugin-syntax-class-static-block": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.25.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1084,13 +1058,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-dynamic-import": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.25.7.tgz",
-      "integrity": "sha512-UvcLuual4h7/GfylKm2IAA3aph9rwvAM2XBA0uPKU3lca+Maai4jBjjEVUS568ld6kJcgbouuumCBhMd/Yz17w==",
+      "version": "7.25.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.25.8.tgz",
+      "integrity": "sha512-gznWY+mr4ZQL/EWPcbBQUP3BXS5FwZp8RUOw06BaRn8tQLzN4XLIxXejpHN9Qo8x8jjBmAAKp6FoS51AgkSA/A==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.7",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3"
+        "@babel/helper-plugin-utils": "^7.25.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1116,13 +1089,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-export-namespace-from": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.25.7.tgz",
-      "integrity": "sha512-h3MDAP5l34NQkkNulsTNyjdaR+OiB0Im67VU//sFupouP8Q6m9Spy7l66DcaAQxtmCqGdanPByLsnwFttxKISQ==",
+      "version": "7.25.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.25.8.tgz",
+      "integrity": "sha512-sPtYrduWINTQTW7FtOy99VCTWp4H23UX7vYcut7S4CIMEXU+54zKX9uCoGkLsWXteyaMXzVHgzWbLfQ1w4GZgw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.7",
-        "@babel/plugin-syntax-export-namespace-from": "^7.8.3"
+        "@babel/helper-plugin-utils": "^7.25.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1181,13 +1153,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-json-strings": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.25.7.tgz",
-      "integrity": "sha512-Ot43PrL9TEAiCe8C/2erAjXMeVSnE/BLEx6eyrKLNFCCw5jvhTHKyHxdI1pA0kz5njZRYAnMO2KObGqOCRDYSA==",
+      "version": "7.25.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.25.8.tgz",
+      "integrity": "sha512-4OMNv7eHTmJ2YXs3tvxAfa/I43di+VcF+M4Wt66c88EAED1RoGaf1D64cL5FkRpNL+Vx9Hds84lksWvd/wMIdA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.7",
-        "@babel/plugin-syntax-json-strings": "^7.8.3"
+        "@babel/helper-plugin-utils": "^7.25.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1212,13 +1183,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-logical-assignment-operators": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.25.7.tgz",
-      "integrity": "sha512-iImzbA55BjiovLyG2bggWS+V+OLkaBorNvc/yJoeeDQGztknRnDdYfp2d/UPmunZYEnZi6Lg8QcTmNMHOB0lGA==",
+      "version": "7.25.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.25.8.tgz",
+      "integrity": "sha512-f5W0AhSbbI+yY6VakT04jmxdxz+WsID0neG7+kQZbCOjuyJNdL5Nn4WIBm4hRpKnUcO9lP0eipUhFN12JpoH8g==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.7",
-        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
+        "@babel/helper-plugin-utils": "^7.25.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1341,13 +1311,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.25.7.tgz",
-      "integrity": "sha512-FbuJ63/4LEL32mIxrxwYaqjJxpbzxPVQj5a+Ebrc8JICV6YX8nE53jY+K0RZT3um56GoNWgkS2BQ/uLGTjtwfw==",
+      "version": "7.25.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.25.8.tgz",
+      "integrity": "sha512-Z7WJJWdQc8yCWgAmjI3hyC+5PXIubH9yRKzkl9ZEG647O9szl9zvmKLzpbItlijBnVhTUf1cpyWBsZ3+2wjWPQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.7",
-        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
+        "@babel/helper-plugin-utils": "^7.25.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1357,13 +1326,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-numeric-separator": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.25.7.tgz",
-      "integrity": "sha512-8CbutzSSh4hmD+jJHIA8vdTNk15kAzOnFLVVgBSMGr28rt85ouT01/rezMecks9pkU939wDInImwCKv4ahU4IA==",
+      "version": "7.25.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.25.8.tgz",
+      "integrity": "sha512-rm9a5iEFPS4iMIy+/A/PiS0QN0UyjPIeVvbU5EMZFKJZHt8vQnasbpo3T3EFcxzCeYO0BHfc4RqooCZc51J86Q==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.7",
-        "@babel/plugin-syntax-numeric-separator": "^7.10.4"
+        "@babel/helper-plugin-utils": "^7.25.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1373,14 +1341,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-object-rest-spread": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.25.7.tgz",
-      "integrity": "sha512-1JdVKPhD7Y5PvgfFy0Mv2brdrolzpzSoUq2pr6xsR+m+3viGGeHEokFKsCgOkbeFOQxfB1Vt2F0cPJLRpFI4Zg==",
+      "version": "7.25.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.25.8.tgz",
+      "integrity": "sha512-LkUu0O2hnUKHKE7/zYOIjByMa4VRaV2CD/cdGz0AxU9we+VA3kDDggKEzI0Oz1IroG+6gUP6UmWEHBMWZU316g==",
       "dev": true,
       "dependencies": {
         "@babel/helper-compilation-targets": "^7.25.7",
         "@babel/helper-plugin-utils": "^7.25.7",
-        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
         "@babel/plugin-transform-parameters": "^7.25.7"
       },
       "engines": {
@@ -1407,13 +1374,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-optional-catch-binding": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.25.7.tgz",
-      "integrity": "sha512-m9obYBA39mDPN7lJzD5WkGGb0GO54PPLXsbcnj1Hyeu8mSRz7Gb4b1A6zxNX32ZuUySDK4G6it8SDFWD1nCnqg==",
+      "version": "7.25.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.25.8.tgz",
+      "integrity": "sha512-EbQYweoMAHOn7iJ9GgZo14ghhb9tTjgOc88xFgYngifx7Z9u580cENCV159M4xDh3q/irbhSjZVpuhpC2gKBbg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.7",
-        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3"
+        "@babel/helper-plugin-utils": "^7.25.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1423,14 +1389,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-optional-chaining": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.25.7.tgz",
-      "integrity": "sha512-h39agClImgPWg4H8mYVAbD1qP9vClFbEjqoJmt87Zen8pjqK8FTPUwrOXAvqu5soytwxrLMd2fx2KSCp2CHcNg==",
+      "version": "7.25.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.25.8.tgz",
+      "integrity": "sha512-q05Bk7gXOxpTHoQ8RSzGSh/LHVB9JEIkKnk3myAWwZHnYiTGYtbdrYkIsS8Xyh4ltKf7GNUSgzs/6P2bJtBAQg==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.7",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.25.7",
-        "@babel/plugin-syntax-optional-chaining": "^7.8.3"
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.25.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1471,15 +1436,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-private-property-in-object": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.25.7.tgz",
-      "integrity": "sha512-LzA5ESzBy7tqj00Yjey9yWfs3FKy4EmJyKOSWld144OxkTji81WWnUT8nkLUn+imN/zHL8ZQlOu/MTUAhHaX3g==",
+      "version": "7.25.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.25.8.tgz",
+      "integrity": "sha512-8Uh966svuB4V8RHHg0QJOB32QK287NBksJOByoKmHMp1TAobNniNalIkI2i5IPj5+S9NYCG4VIjbEuiSN8r+ow==",
       "dev": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.25.7",
         "@babel/helper-create-class-features-plugin": "^7.25.7",
-        "@babel/helper-plugin-utils": "^7.25.7",
-        "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.25.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1758,12 +1722,12 @@
       }
     },
     "node_modules/@babel/preset-env": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.25.7.tgz",
-      "integrity": "sha512-Gibz4OUdyNqqLj+7OAvBZxOD7CklCtMA5/j0JgUEwOnaRULsPDXmic2iKxL2DX2vQduPR5wH2hjZas/Vr/Oc0g==",
+      "version": "7.25.8",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.25.8.tgz",
+      "integrity": "sha512-58T2yulDHMN8YMUxiLq5YmWUnlDCyY1FsHM+v12VMx+1/FlrUj5tY50iDCpofFQEM8fMYOaY9YRvym2jcjn1Dg==",
       "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.25.7",
+        "@babel/compat-data": "^7.25.8",
         "@babel/helper-compilation-targets": "^7.25.7",
         "@babel/helper-plugin-utils": "^7.25.7",
         "@babel/helper-validator-option": "^7.25.7",
@@ -1773,45 +1737,30 @@
         "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.25.7",
         "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.25.7",
         "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
-        "@babel/plugin-syntax-async-generators": "^7.8.4",
-        "@babel/plugin-syntax-class-properties": "^7.12.13",
-        "@babel/plugin-syntax-class-static-block": "^7.14.5",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-syntax-export-namespace-from": "^7.8.3",
         "@babel/plugin-syntax-import-assertions": "^7.25.7",
         "@babel/plugin-syntax-import-attributes": "^7.25.7",
-        "@babel/plugin-syntax-import-meta": "^7.10.4",
-        "@babel/plugin-syntax-json-strings": "^7.8.3",
-        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
-        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
-        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
-        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
-        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
-        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
-        "@babel/plugin-syntax-top-level-await": "^7.14.5",
         "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
         "@babel/plugin-transform-arrow-functions": "^7.25.7",
-        "@babel/plugin-transform-async-generator-functions": "^7.25.7",
+        "@babel/plugin-transform-async-generator-functions": "^7.25.8",
         "@babel/plugin-transform-async-to-generator": "^7.25.7",
         "@babel/plugin-transform-block-scoped-functions": "^7.25.7",
         "@babel/plugin-transform-block-scoping": "^7.25.7",
         "@babel/plugin-transform-class-properties": "^7.25.7",
-        "@babel/plugin-transform-class-static-block": "^7.25.7",
+        "@babel/plugin-transform-class-static-block": "^7.25.8",
         "@babel/plugin-transform-classes": "^7.25.7",
         "@babel/plugin-transform-computed-properties": "^7.25.7",
         "@babel/plugin-transform-destructuring": "^7.25.7",
         "@babel/plugin-transform-dotall-regex": "^7.25.7",
         "@babel/plugin-transform-duplicate-keys": "^7.25.7",
         "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.25.7",
-        "@babel/plugin-transform-dynamic-import": "^7.25.7",
+        "@babel/plugin-transform-dynamic-import": "^7.25.8",
         "@babel/plugin-transform-exponentiation-operator": "^7.25.7",
-        "@babel/plugin-transform-export-namespace-from": "^7.25.7",
+        "@babel/plugin-transform-export-namespace-from": "^7.25.8",
         "@babel/plugin-transform-for-of": "^7.25.7",
         "@babel/plugin-transform-function-name": "^7.25.7",
-        "@babel/plugin-transform-json-strings": "^7.25.7",
+        "@babel/plugin-transform-json-strings": "^7.25.8",
         "@babel/plugin-transform-literals": "^7.25.7",
-        "@babel/plugin-transform-logical-assignment-operators": "^7.25.7",
+        "@babel/plugin-transform-logical-assignment-operators": "^7.25.8",
         "@babel/plugin-transform-member-expression-literals": "^7.25.7",
         "@babel/plugin-transform-modules-amd": "^7.25.7",
         "@babel/plugin-transform-modules-commonjs": "^7.25.7",
@@ -1819,15 +1768,15 @@
         "@babel/plugin-transform-modules-umd": "^7.25.7",
         "@babel/plugin-transform-named-capturing-groups-regex": "^7.25.7",
         "@babel/plugin-transform-new-target": "^7.25.7",
-        "@babel/plugin-transform-nullish-coalescing-operator": "^7.25.7",
-        "@babel/plugin-transform-numeric-separator": "^7.25.7",
-        "@babel/plugin-transform-object-rest-spread": "^7.25.7",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.25.8",
+        "@babel/plugin-transform-numeric-separator": "^7.25.8",
+        "@babel/plugin-transform-object-rest-spread": "^7.25.8",
         "@babel/plugin-transform-object-super": "^7.25.7",
-        "@babel/plugin-transform-optional-catch-binding": "^7.25.7",
-        "@babel/plugin-transform-optional-chaining": "^7.25.7",
+        "@babel/plugin-transform-optional-catch-binding": "^7.25.8",
+        "@babel/plugin-transform-optional-chaining": "^7.25.8",
         "@babel/plugin-transform-parameters": "^7.25.7",
         "@babel/plugin-transform-private-methods": "^7.25.7",
-        "@babel/plugin-transform-private-property-in-object": "^7.25.7",
+        "@babel/plugin-transform-private-property-in-object": "^7.25.8",
         "@babel/plugin-transform-property-literals": "^7.25.7",
         "@babel/plugin-transform-regenerator": "^7.25.7",
         "@babel/plugin-transform-reserved-words": "^7.25.7",
@@ -2116,9 +2065,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.7.tgz",
-      "integrity": "sha512-vwIVdXG+j+FOpkwqHRcBgHLYNL7XMkufrlaFvL9o6Ai9sJn9+PdyIL5qa0XzTZw084c+u9LOls53eoZWP/W5WQ==",
+      "version": "7.25.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.8.tgz",
+      "integrity": "sha512-JWtuCu8VQsMladxVz/P4HzHUGCAwpuqacmowgXFs5XjxIgKuNjnLokQzuVjlTvIzODaDmpjT3oxcC48vyk9EWg==",
       "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.25.7",
@@ -10499,9 +10448,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001667",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001667.tgz",
-      "integrity": "sha512-7LTwJjcRkzKFmtqGsibMeuXmvFDfZq/nzIjnmgCGzKKRVzjD72selLDK1oPF/Oxzmt4fNcPvTDvGqSDG4tCALw==",
+      "version": "1.0.30001668",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001668.tgz",
+      "integrity": "sha512-nWLrdxqCdblixUO+27JtGJJE/txpJlyUy5YN1u53wLZkP0emYCo5zgS6QYft7VUYR42LGgi/S5hdLZTrnyIddw==",
       "dev": true,
       "funding": [
         {
@@ -11850,9 +11799,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.35",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.35.tgz",
-      "integrity": "sha512-hOSRInrIDm0Brzp4IHW2F/VM+638qOL2CzE0DgpnGzKW27C95IqqeqgKz/hxHGnvPxvQGpHUGD5qRVC9EZY2+A==",
+      "version": "1.5.36",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.36.tgz",
+      "integrity": "sha512-HYTX8tKge/VNp6FGO+f/uVDmUkq+cEfcxYhKf15Akc4M5yxt5YmorwlAitKWjWhWQnKcDRBAQKXkhqqXMqcrjw==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -13323,9 +13272,9 @@
       "dev": true
     },
     "node_modules/flow-parser": {
-      "version": "0.247.1",
-      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.247.1.tgz",
-      "integrity": "sha512-DHwcm06fWbn2Z6uFD3NaBZ5lMOoABIQ4asrVA80IWvYjjT5WdbghkUOL1wIcbLcagnFTdCZYOlSNnKNp/xnRZQ==",
+      "version": "0.248.1",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.248.1.tgz",
+      "integrity": "sha512-fkCfVPelbTzSVp+jVwSvEyc+I4WG8MNhRG/EWSZZTlgHAMEdhXJaFEbfErXxMktboMhVGchvEFhWxkzNGM1m2A==",
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
@@ -18742,12 +18691,12 @@
       }
     },
     "node_modules/parse5": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
-      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.2.0.tgz",
+      "integrity": "sha512-ZkDsAOcxsUMZ4Lz5fVciOehNcJ+Gb8gTzcA4yl3wnc273BAybYWrQ+Ks/OjCjSEpjvQkDSeZbybK9qj2VHHdGA==",
       "dev": true,
       "dependencies": {
-        "entities": "^4.4.0"
+        "entities": "^4.5.0"
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
@@ -20927,9 +20876,9 @@
       "dev": true
     },
     "node_modules/sirv": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
-      "integrity": "sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.0.tgz",
+      "integrity": "sha512-BPwJGUeDaDCHihkORDchNyyTvWFhcusy1XMmhEVTQTwGeybFbp8YEmB+njbPnth1FibULBSBVwCQni25XlCUDg==",
       "dev": true,
       "dependencies": {
         "@polka/url": "^1.0.0-next.24",
@@ -20937,38 +20886,29 @@
         "totalist": "^3.0.0"
       },
       "engines": {
-        "node": ">= 10"
+        "node": ">=18"
       }
     },
     "node_modules/sirv-cli": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/sirv-cli/-/sirv-cli-2.0.2.tgz",
-      "integrity": "sha512-OtSJDwxsF1NWHc7ps3Sa0s+dPtP15iQNJzfKVz+MxkEo3z72mCD+yu30ct79rPr0CaV1HXSOBp+MIY5uIhHZ1A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/sirv-cli/-/sirv-cli-3.0.0.tgz",
+      "integrity": "sha512-p88yHl8DmTOUJroRiW2o9ezJc/YRLxphBydX2NGQc3naKBA09B3EM4Q/yaN8FYF0e50fRSZP7dyatr72b1u5Jw==",
       "dev": true,
       "dependencies": {
         "console-clear": "^1.1.0",
-        "get-port": "^3.2.0",
+        "get-port": "^5.1.1",
         "kleur": "^4.1.4",
         "local-access": "^1.0.1",
         "sade": "^1.6.0",
         "semiver": "^1.0.0",
-        "sirv": "^2.0.0",
+        "sirv": "^3.0.0",
         "tinydate": "^1.0.0"
       },
       "bin": {
         "sirv": "bin.js"
       },
       "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/sirv-cli/node_modules/get-port": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
-      "integrity": "sha512-x5UJKlgeUiNT8nyo/AcnwLnZuZNcSjSw0kogRB+Whd1fjjFq4B1hySFxSFWWSn4mIBzg3sRNUDFYc4g5gjPoLg==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
+        "node": ">=18"
       }
     },
     "node_modules/sirv-cli/node_modules/kleur": {
@@ -21756,9 +21696,9 @@
       }
     },
     "node_modules/tocbot": {
-      "version": "4.30.0",
-      "resolved": "https://registry.npmjs.org/tocbot/-/tocbot-4.30.0.tgz",
-      "integrity": "sha512-c0ucneDHP5zqsbczYxjRj1SWD+6EeD1mUbQPTdVJzNe0aAZH4NyeZt4cQQBjWU4v8tTlJtzDzEgD03sCc5nL1w==",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/tocbot/-/tocbot-4.31.0.tgz",
+      "integrity": "sha512-Zd9tt6EQn2bvLSHIcug/Z1Sukyn/XJ62dMK9SjIbtHSDkI+Du40CmBvds6BedzXZe1sS1iPGl4Wup/k4cJkVhQ==",
       "dev": true
     },
     "node_modules/toidentifier": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "rollup": "^4.9.2",
     "rollup-plugin-postcss": "^4.0.2",
     "rollup-plugin-visualizer": "^5.12.0",
-    "sirv-cli": "^2.0.2",
+    "sirv-cli": "^3.0.0",
     "storybook": "^7.6.6",
     "storybook-css-modules": "^1.0.8"
   },


### PR DESCRIPTION
- Dependabot: Bump @babel/plugin-transform-optional-catch-binding
- Dependabot: Bump @babel/plugin-transform-numeric-separator
- Dependabot: Bump @babel/core from 7.25.7 to 7.25.8
- Dependabot: Bump @babel/plugin-transform-private-property-in-object
- Dependabot: Bump @babel/plugin-transform-export-namespace-from
- Dependabot: Bump @babel/plugin-transform-object-rest-spread
- Dependabot: Bump caniuse-lite from 1.0.30001667 to 1.0.30001668
- Dependabot: Bump @babel/compat-data from 7.25.7 to 7.25.8
- Dependabot: Bump @babel/parser from 7.25.7 to 7.25.8
- Dependabot: Bump @babel/plugin-transform-dynamic-import
- Dependabot: Bump @babel/preset-env from 7.25.7 to 7.25.8
- Dependabot: Bump @babel/types from 7.25.7 to 7.25.8
- Dependabot: Bump @babel/plugin-transform-optional-chaining
- Dependabot: Bump @babel/plugin-transform-json-strings
- Dependabot: Bump @babel/plugin-transform-nullish-coalescing-operator
- Dependabot: Bump @babel/plugin-transform-async-generator-functions
- Dependabot: Bump @babel/plugin-transform-class-static-block
- Dependabot: Bump @babel/eslint-parser from 7.25.7 to 7.25.8
- Dependabot: Bump @babel/plugin-transform-logical-assignment-operators
- Dependabot: Bump electron-to-chromium from 1.5.35 to 1.5.36
- Dependabot: Bump sirv-cli from 2.0.2 to 3.0.0
- Dependabot: Bump parse5 from 7.1.2 to 7.2.0
- Dependabot: Bump flow-parser from 0.247.1 to 0.248.1
- Dependabot: Bump tocbot from 4.30.0 to 4.31.0
- Dependabot: Bump preact from 10.24.2 to 10.24.3
