### PR TITLE
combine all dependabot prs 2024 10 15 9069

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11799,9 +11799,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.36",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.36.tgz",
-      "integrity": "sha512-HYTX8tKge/VNp6FGO+f/uVDmUkq+cEfcxYhKf15Akc4M5yxt5YmorwlAitKWjWhWQnKcDRBAQKXkhqqXMqcrjw==",
+      "version": "1.5.38",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.38.tgz",
+      "integrity": "sha512-VbeVexmZ1IFh+5EfrYz1I0HTzHVIlJa112UEWhciPyeOcKJGeTv6N8WnG4wsQB81DGCaVEGhpSb6o6a8WYFXXg==",
       "dev": true
     },
     "node_modules/emittery": {


### PR DESCRIPTION
- Dependabot: Bump vite from 5.4.8 to 5.4.9
- Dependabot: Bump marked from 14.1.2 to 14.1.3
- Dependabot: Bump electron-to-chromium from 1.5.36 to 1.5.38
