### PR TITLE
combine all dependabot prs 2024 10 17 5250

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13272,9 +13272,9 @@
       "dev": true
     },
     "node_modules/flow-parser": {
-      "version": "0.248.1",
-      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.248.1.tgz",
-      "integrity": "sha512-fkCfVPelbTzSVp+jVwSvEyc+I4WG8MNhRG/EWSZZTlgHAMEdhXJaFEbfErXxMktboMhVGchvEFhWxkzNGM1m2A==",
+      "version": "0.249.0",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.249.0.tgz",
+      "integrity": "sha512-ggx9WtnEWgDt+VNOy6r34nqzQ1D/ns+brWHHlcPvU61QHK/HRQ6mFpPiuwtYNe4Z09Yv6ByTfnd7IR9GjT0Jog==",
       "dev": true,
       "engines": {
         "node": ">=0.4.0"


### PR DESCRIPTION
- Dependabot: Bump @rollup/plugin-commonjs from 28.0.0 to 28.0.1
- Dependabot: Bump acorn from 8.12.1 to 8.13.0
- Dependabot: Bump caniuse-lite from 1.0.30001668 to 1.0.30001669
- Dependabot: Bump @types/node from 18.19.55 to 18.19.56
- Dependabot: Bump picocolors from 1.1.0 to 1.1.1
- Dependabot: Bump electron-to-chromium from 1.5.38 to 1.5.40
- Dependabot: Bump fdir from 6.4.0 to 6.4.2
- Dependabot: Bump flow-parser from 0.248.1 to 0.249.0
