### PR TITLE
combine all dependabot prs 2024 10 24 5982

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -398,9 +398,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.7.tgz",
-      "integrity": "sha512-AM6TzwYqGChO45oiuPqwL2t20/HdMC1rTPAesnBCgPCSF1x3oN9MVUwQV2iyz4xqWrctwK5RNC8LV22kaQCNYg==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -443,12 +443,12 @@
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.25.7.tgz",
-      "integrity": "sha512-iYyACpW3iW8Fw+ZybQK+drQre+ns/tKpXbNESfrhNnPLIklLbXr7MYJ6gPEd0iETGLOK+SxMjVvKb/ffmk+FEw==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.25.9.tgz",
+      "integrity": "sha512-llL88JShoCsth8fF8R4SJnIn+WLvR6ccFxu1H3FlMhDontdcmZWf2HgIZ7AIqV3Xcck1idlohrN4EUBQz6klbw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.25.7",
+        "@babel/helper-validator-identifier": "^7.25.9",
         "chalk": "^2.4.2",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.0.0"


### PR DESCRIPTION
- Dependabot: Bump @babel/helper-annotate-as-pure from 7.25.7 to 7.25.9
- Dependabot: Bump @babel/preset-env from 7.25.8 to 7.25.9
- Dependabot: Bump @babel/compat-data from 7.25.8 to 7.25.9
- Dependabot: Bump @babel/types from 7.25.8 to 7.25.9
- Dependabot: Bump @babel/plugin-transform-optional-chaining
- Dependabot: Bump @babel/plugin-transform-async-generator-functions
- Dependabot: Bump eslint-plugin-react from 7.37.1 to 7.37.2
- Dependabot: Bump @babel/helper-replace-supers from 7.25.7 to 7.25.9
- Dependabot: Bump @babel/plugin-transform-object-rest-spread
- Dependabot: Bump @babel/helper-module-transforms from 7.25.7 to 7.25.9
- Dependabot: Bump @babel/plugin-bugfix-firefox-class-in-computed-class-key
- Dependabot: Bump @babel/plugin-transform-react-jsx-development
- Dependabot: Bump @babel/plugin-transform-private-methods
- Dependabot: Bump @babel/plugin-transform-async-to-generator
- Dependabot: Bump @babel/register from 7.25.7 to 7.25.9
- Dependabot: Bump @babel/plugin-transform-typeof-symbol
- Dependabot: Bump @babel/plugin-transform-destructuring
- Dependabot: Bump @babel/plugin-transform-parameters
- Dependabot: Bump @babel/plugin-transform-object-super
- Dependabot: Bump @babel/helpers from 7.25.7 to 7.25.9
- Dependabot: Bump @babel/plugin-transform-reserved-words
- Dependabot: Bump @babel/plugin-syntax-typescript from 7.25.7 to 7.25.9
- Dependabot: Bump @babel/plugin-bugfix-safari-class-field-initializer-scope
- Dependabot: Bump @babel/helper-member-expression-to-functions
- Dependabot: Bump @babel/plugin-transform-dotall-regex
- Dependabot: Bump @babel/plugin-transform-duplicate-keys
- Dependabot: Bump @babel/plugin-transform-numeric-separator
- Dependabot: Bump @babel/plugin-syntax-jsx from 7.25.7 to 7.25.9
- Dependabot: Bump @babel/core from 7.25.8 to 7.25.9
- Dependabot: Bump @babel/highlight from 7.25.7 to 7.25.9
