### PR TITLE
combine all dependabot prs 2024 11 01 4823

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6608,9 +6608,9 @@
       }
     },
     "node_modules/@storybook/builder-vite/node_modules/@types/node": {
-      "version": "18.19.59",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.59.tgz",
-      "integrity": "sha512-vizm2EqwV/7Zay+A6J3tGl9Lhr7CjZe2HmWS988sefiEmsyP9CeXEleho6i4hJk/8UtZAo0bWN4QPZZr83RxvQ==",
+      "version": "18.19.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.63.tgz",
+      "integrity": "sha512-hcUB7THvrGmaEcPcvUZCZtQ2Z3C+UR/aOcraBLCvTsFMh916Gc1kCCYcfcMuB76HM2pSerxl1PoP3KnmHzd9Lw==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -7056,9 +7056,9 @@
       }
     },
     "node_modules/@storybook/core-common/node_modules/@types/node": {
-      "version": "18.19.59",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.59.tgz",
-      "integrity": "sha512-vizm2EqwV/7Zay+A6J3tGl9Lhr7CjZe2HmWS988sefiEmsyP9CeXEleho6i4hJk/8UtZAo0bWN4QPZZr83RxvQ==",
+      "version": "18.19.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.63.tgz",
+      "integrity": "sha512-hcUB7THvrGmaEcPcvUZCZtQ2Z3C+UR/aOcraBLCvTsFMh916Gc1kCCYcfcMuB76HM2pSerxl1PoP3KnmHzd9Lw==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -7195,9 +7195,9 @@
       }
     },
     "node_modules/@storybook/core-server/node_modules/@types/node": {
-      "version": "18.19.59",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.59.tgz",
-      "integrity": "sha512-vizm2EqwV/7Zay+A6J3tGl9Lhr7CjZe2HmWS988sefiEmsyP9CeXEleho6i4hJk/8UtZAo0bWN4QPZZr83RxvQ==",
+      "version": "18.19.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.63.tgz",
+      "integrity": "sha512-hcUB7THvrGmaEcPcvUZCZtQ2Z3C+UR/aOcraBLCvTsFMh916Gc1kCCYcfcMuB76HM2pSerxl1PoP3KnmHzd9Lw==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -8896,12 +8896,12 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "22.7.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.9.tgz",
-      "integrity": "sha512-jrTfRC7FM6nChvU7X2KqcrgquofrWLFDeYC1hKfwNWomVvrn7JIksqf344WN2X/y8xrgqBd2dJATZV4GbatBfg==",
+      "version": "22.8.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.8.6.tgz",
+      "integrity": "sha512-tosuJYKrIqjQIlVCM4PEGxOmyg3FCPa/fViuJChnGeEIhjA46oy8FMVoF9su1/v8PNs2a8Q0iFNyOx0uOF91nw==",
       "dev": true,
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~6.19.8"
       }
     },
     "node_modules/@types/node-fetch": {
@@ -8915,9 +8915,9 @@
       }
     },
     "node_modules/@types/node/node_modules/undici-types": {
-      "version": "6.19.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.6.tgz",
-      "integrity": "sha512-e/vggGopEfTKSvj4ihnOLTsqhrKRN3LeO6qSN/GxohhuRv8qH9bNQ4B8W7e/vFL+0XTnmHPB4/kegunZGA4Org==",
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {


### PR DESCRIPTION
- Dependabot: Bump @babel/runtime from 7.25.9 to 7.26.0
- Dependabot: Bump acorn from 8.13.0 to 8.14.0
- Dependabot: Bump parse5 from 7.2.0 to 7.2.1
- Dependabot: Bump @babel/helpers from 7.25.9 to 7.26.0
- Dependabot: Bump @babel/plugin-syntax-import-attributes
- Dependabot: Bump @babel/types from 7.25.9 to 7.26.0
- Dependabot: Bump @babel/plugin-syntax-flow from 7.25.9 to 7.26.0
- Dependabot: Bump @eslint-community/eslint-utils from 4.4.0 to 4.4.1
- Dependabot: Bump @eslint-community/regexpp from 4.11.1 to 4.12.1
- Dependabot: Bump @babel/helper-module-transforms from 7.25.9 to 7.26.0
- Dependabot: Bump @babel/plugin-syntax-import-assertions
- Dependabot: Bump @babel/preset-typescript from 7.25.9 to 7.26.0
- Dependabot: Bump @babel/plugin-transform-class-static-block
- Dependabot: Bump unplugin from 1.14.1 to 1.15.0
- Dependabot: Bump rollup from 4.24.0 to 4.24.3
- Dependabot: Bump @floating-ui/dom from 1.6.11 to 1.6.12
- Dependabot: Bump @typescript-eslint/utils from 8.11.0 to 8.12.2
- Dependabot: Bump @types/lodash from 4.17.12 to 4.17.13
- Dependabot: Bump @babel/compat-data from 7.25.9 to 7.26.2
- Dependabot: Bump @babel/parser from 7.25.9 to 7.26.2
- Dependabot: Bump @babel/generator from 7.25.9 to 7.26.2
- Dependabot: Bump ts-api-utils from 1.3.0 to 1.4.0
- Dependabot: Bump @babel/code-frame from 7.25.9 to 7.26.2
- Dependabot: Bump core-js from 3.38.1 to 3.39.0
- Dependabot: Bump caniuse-lite from 1.0.30001669 to 1.0.30001676
- Dependabot: Bump core-js-compat from 3.38.1 to 3.39.0
- Dependabot: Bump flow-parser from 0.250.0 to 0.251.1
- Dependabot: Bump compression from 1.7.4 to 1.7.5
- Dependabot: Bump electron-to-chromium from 1.5.45 to 1.5.50
- Dependabot: Bump @types/node from 18.19.59 to 18.19.63
