### PR TITLE
combine all dependabot prs 2024 11 01 2154

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1534,6 +1534,22 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-transform-regexp-modifiers": {
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.26.0.tgz",
+      "integrity": "sha512-vN6saax7lrA2yA/Pak3sCxuD6F5InBjn9IcrIKQPjpsLvuHYLVroTxjdlVRHjjBWxKOqIwpTXDkOssYT4BFdRw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
     "node_modules/@babel/plugin-transform-reserved-words": {
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.25.9.tgz",
@@ -1708,12 +1724,12 @@
       }
     },
     "node_modules/@babel/preset-env": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.25.9.tgz",
-      "integrity": "sha512-XqDEt+hfsQukahSX9JOBDHhpUHDhj2zGSxoqWQFCMajOSBnbhBdgON/bU/5PkBA1yX5tqW6tTzuIPVsZTQ7h5Q==",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.26.0.tgz",
+      "integrity": "sha512-H84Fxq0CQJNdPFT2DrfnylZ3cf5K43rGfWK4LJGPpjKHiZlk0/RzwEus3PDDZZg+/Er7lCA03MVacueUuXdzfw==",
       "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.25.9",
+        "@babel/compat-data": "^7.26.0",
         "@babel/helper-compilation-targets": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9",
         "@babel/helper-validator-option": "^7.25.9",
@@ -1723,8 +1739,8 @@
         "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.25.9",
         "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.25.9",
         "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
-        "@babel/plugin-syntax-import-assertions": "^7.25.9",
-        "@babel/plugin-syntax-import-attributes": "^7.25.9",
+        "@babel/plugin-syntax-import-assertions": "^7.26.0",
+        "@babel/plugin-syntax-import-attributes": "^7.26.0",
         "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
         "@babel/plugin-transform-arrow-functions": "^7.25.9",
         "@babel/plugin-transform-async-generator-functions": "^7.25.9",
@@ -1732,7 +1748,7 @@
         "@babel/plugin-transform-block-scoped-functions": "^7.25.9",
         "@babel/plugin-transform-block-scoping": "^7.25.9",
         "@babel/plugin-transform-class-properties": "^7.25.9",
-        "@babel/plugin-transform-class-static-block": "^7.25.9",
+        "@babel/plugin-transform-class-static-block": "^7.26.0",
         "@babel/plugin-transform-classes": "^7.25.9",
         "@babel/plugin-transform-computed-properties": "^7.25.9",
         "@babel/plugin-transform-destructuring": "^7.25.9",
@@ -1765,6 +1781,7 @@
         "@babel/plugin-transform-private-property-in-object": "^7.25.9",
         "@babel/plugin-transform-property-literals": "^7.25.9",
         "@babel/plugin-transform-regenerator": "^7.25.9",
+        "@babel/plugin-transform-regexp-modifiers": "^7.26.0",
         "@babel/plugin-transform-reserved-words": "^7.25.9",
         "@babel/plugin-transform-shorthand-properties": "^7.25.9",
         "@babel/plugin-transform-spread": "^7.25.9",


### PR DESCRIPTION
- Dependabot: Bump regjsparser from 0.11.1 to 0.11.2
- Dependabot: Bump @babel/core from 7.25.9 to 7.26.0
- Dependabot: Bump @babel/preset-env from 7.25.9 to 7.26.0
