### PR TITLE
combine all dependabot prs 2024 11 10 10655

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11771,9 +11771,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.52",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.52.tgz",
-      "integrity": "sha512-xtoijJTZ+qeucLBDNztDOuQBE1ksqjvNjvqFoST3nGC7fSpqJ+X6BdTBaY5BHG+IhWWmpc6b/KfpeuEDupEPOQ==",
+      "version": "1.5.55",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.55.tgz",
+      "integrity": "sha512-6maZ2ASDOTBtjt9FhqYPRnbvKU5tjG0IN9SztUOWYw2AzNDNpKJYLJmlK0/En4Hs/aiWnB+JZ+gW19PIGszgKg==",
       "dev": true
     },
     "node_modules/emittery": {


### PR DESCRIPTION
- Dependabot: Bump flow-parser from 0.251.1 to 0.252.0
- Dependabot: Bump caniuse-lite from 1.0.30001677 to 1.0.30001679
- Dependabot: Bump psl from 1.9.0 to 1.10.0
- Dependabot: Bump marked from 14.1.3 to 14.1.4
- Dependabot: Bump cross-spawn from 7.0.3 to 7.0.5
- Dependabot: Bump electron-to-chromium from 1.5.52 to 1.5.55
