### PR TITLE
combine all dependabot prs 2024 11 12 6747

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18845,9 +18845,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.47",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
-      "integrity": "sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==",
+      "version": "8.4.48",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.48.tgz",
+      "integrity": "sha512-GCRK8F6+Dl7xYniR5a4FYbpBzU8XnZVeowqsQFYdcXuSbChgiks7qybSkbvnaeqv0G0B+dd9/jJgH8kkLDQeEA==",
       "dev": true,
       "funding": [
         {
@@ -18866,7 +18866,7 @@
       "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
-        "picocolors": "^1.1.0",
+        "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
       "engines": {


### PR DESCRIPTION
- Dependabot: Bump tocbot from 4.31.0 to 4.32.2
- Dependabot: Bump rollup from 4.24.4 to 4.25.0
- Dependabot: Bump vite from 5.4.10 to 5.4.11
- Dependabot: Bump caniuse-lite from 1.0.30001679 to 1.0.30001680
- Dependabot: Bump object-inspect from 1.13.2 to 1.13.3
- Dependabot: Bump postcss from 8.4.47 to 8.4.48
