### PR TITLE
combine all dependabot prs 2024 11 13 1203

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11771,9 +11771,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.55",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.55.tgz",
-      "integrity": "sha512-6maZ2ASDOTBtjt9FhqYPRnbvKU5tjG0IN9SztUOWYw2AzNDNpKJYLJmlK0/En4Hs/aiWnB+JZ+gW19PIGszgKg==",
+      "version": "1.5.56",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.56.tgz",
+      "integrity": "sha512-7lXb9dAvimCFdvUMTyucD4mnIndt/xhRKFAlky0CyFogdnNmdPQNoHI23msF/2V4mpTxMzgMdjK4+YRlFlRQZw==",
       "dev": true
     },
     "node_modules/emittery": {


### PR DESCRIPTION
- Dependabot: Bump postcss-modules-scope from 3.2.0 to 3.2.1
- Dependabot: Bump babel-plugin-polyfill-regenerator from 0.6.2 to 0.6.3
- Dependabot: Bump mlly from 1.7.2 to 1.7.3
- Dependabot: Bump @babel/helper-define-polyfill-provider
- Dependabot: Bump @typescript-eslint/utils from 8.13.0 to 8.14.0
- Dependabot: Bump @types/node-fetch from 2.6.11 to 2.6.12
- Dependabot: Bump postcss-modules-local-by-default from 4.0.5 to 4.1.0
- Dependabot: Bump babel-plugin-polyfill-corejs2 from 0.4.11 to 0.4.12
- Dependabot: Bump electron-to-chromium from 1.5.55 to 1.5.56
