### PR TITLE
combine all dependabot prs 2024 11 16 1984

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13226,9 +13226,9 @@
       "dev": true
     },
     "node_modules/flow-parser": {
-      "version": "0.252.0",
-      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.252.0.tgz",
-      "integrity": "sha512-z8hKPUjZ33VLn4HVntifqmEhmolUMopysnMNzazoDqo1GLUkBsreLNsxETlKJMPotUWStQnen6SGvUNe1j4Hlg==",
+      "version": "0.253.0",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.253.0.tgz",
+      "integrity": "sha512-EbxtzRIzp8dDSzTloPhsc6uOvrEFIyu08cqQzXBWLAgxK+i2d/5qOos9ryQHRmk+RyDDXfnz/7qteh3jnAlc4w==",
       "dev": true,
       "engines": {
         "node": ">=0.4.0"


### PR DESCRIPTION
- Dependabot: Bump unplugin from 1.15.0 to 1.16.0
- Dependabot: Bump @adobe/css-tools from 4.4.0 to 4.4.1
- Dependabot: Bump es-abstract from 1.23.4 to 1.23.5
- Dependabot: Bump electron-to-chromium from 1.5.57 to 1.5.60
- Dependabot: Bump rollup from 4.26.0 to 4.27.0
- Dependabot: Bump flow-parser from 0.252.0 to 0.253.0
