### PR TITLE
combine all dependabot prs 2024 11 19 2093

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17546,9 +17546,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.0.tgz",
-      "integrity": "sha512-0mouKmBROJv/WSHJBPZZyYofUgawMChnD5je/g+aOBXsHDjb/IsnTQj7mnhQZu+qPJmRQ0ecX3mLGEUm3BgwYA==",
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.1.tgz",
+      "integrity": "sha512-VnnE19XO2Vb2oZeH8quAepfrb6Aaz4OoY8yZQACfuy/5KVJ0GxYC0Qxzz/iuc+g5UF7H0HJ+QROfvH26XeBdDA==",
       "dev": true,
       "bin": {
         "marked": "bin/marked.js"


### PR DESCRIPTION
- Dependabot: Bump @prefresh/core from 1.5.2 to 1.5.3
- Dependabot: Bump marked from 15.0.0 to 15.0.1
