### PR TITLE
combine all dependabot prs 2024 11 20 2903

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10988,9 +10988,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.5.tgz",
-      "integrity": "sha512-ZVJrKKYunU38/76t0RMOulHOnUcbU9GbpWKAOZ0mhjr7CX6FVrH+4FrAapSOekrgFQ3f/8gwMEuIft0aKq6Hug==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",


### PR DESCRIPTION
- Dependabot: Bump rollup from 4.27.2 to 4.27.3
- Dependabot: Bump @typescript-eslint/utils from 8.14.0 to 8.15.0
- Dependabot: Bump flatted from 3.3.1 to 3.3.2
- Dependabot: Bump electron-to-chromium from 1.5.62 to 1.5.63
- Dependabot: Bump eslint-plugin-storybook from 0.11.0 to 0.11.1
- Dependabot: Bump cross-spawn from 7.0.5 to 7.0.6
