### PR TITLE
combine all dependabot prs 2024 11 21 1048

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10445,9 +10445,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001680",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001680.tgz",
-      "integrity": "sha512-rPQy70G6AGUMnbwS1z6Xg+RkHYPAi18ihs47GH0jcxIG7wArmPgY3XbS2sRdBbxJljp3thdT8BIqv9ccCypiPA==",
+      "version": "1.0.30001683",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001683.tgz",
+      "integrity": "sha512-iqmNnThZ0n70mNwvxpEC2nBJ037ZHZUoBI5Gorh1Mw6IlEAZujEoU1tXA628iZfzm7R9FvFzxbfdgml82a3k8Q==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
- Dependabot: Bump marked from 15.0.1 to 15.0.2
- Dependabot: Bump flow-parser from 0.253.0 to 0.254.0
- Dependabot: Bump psl from 1.10.0 to 1.11.0
- Dependabot: Bump caniuse-lite from 1.0.30001680 to 1.0.30001683
