### PR TITLE
combine all dependabot prs 2024 11 25 3253

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11776,9 +11776,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.63",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.63.tgz",
-      "integrity": "sha512-ddeXKuY9BHo/mw145axlyWjlJ1UBt4WK3AlvkT7W2AbqfRQoacVoRUCF6wL3uIx/8wT9oLKXzI+rFqHHscByaA==",
+      "version": "1.5.64",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.64.tgz",
+      "integrity": "sha512-IXEuxU+5ClW2IGEYFC2T7szbyVgehupCWQe5GNh+H065CD6U6IFN0s4KeAMFGNmQolRU4IV7zGBWSYMmZ8uuqQ==",
       "dev": true
     },
     "node_modules/emittery": {


### PR DESCRIPTION
- Dependabot: Bump typed-array-byte-offset from 1.0.2 to 1.0.3
- Dependabot: Bump psl from 1.11.0 to 1.13.0
- Dependabot: Bump flow-parser from 0.254.0 to 0.254.1
- Dependabot: Bump preact from 10.24.3 to 10.25.0
- Dependabot: Bump regexpu-core from 6.1.1 to 6.2.0
- Dependabot: Bump electron-to-chromium from 1.5.63 to 1.5.64
