### PR TITLE
combine all dependabot prs 2024 11 29 7639

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22923,10 +22923,11 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.15.tgz",
-      "integrity": "sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.16.tgz",
+      "integrity": "sha512-g+N+GAWiRj66DngFwHvISJd+ITsyphZvD1vChfVg6cEdnzy53GzB3oy0fUNlvhz7H7+MiqhYr26qxQShCpKTTQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
         "call-bind": "^1.0.7",


### PR DESCRIPTION
- Dependabot: Bump @preact/preset-vite from 2.9.1 to 2.9.2
- Dependabot: Bump electron-to-chromium from 1.5.65 to 1.5.66
- Dependabot: Bump @types/node from 18.19.66 to 18.19.67
- Dependabot: Bump which-typed-array from 1.1.15 to 1.1.16
