### PR TITLE
combine all dependabot prs 2024 11 30 2454

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11791,9 +11791,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.66",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.66.tgz",
-      "integrity": "sha512-pI2QF6+i+zjPbqRzJwkMvtvkdI7MjVbSh2g8dlMguDJIXEPw+kwasS1Jl+YGPEBfGVxsVgGUratAKymPdPo2vQ==",
+      "version": "1.5.67",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.67.tgz",
+      "integrity": "sha512-nz88NNBsD7kQSAGGJyp8hS6xSPtWwqNogA0mjtc2nUYeEf3nURK9qpV18TuBdDmEDgVWotS8Wkzf+V52dSQ/LQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -17572,10 +17572,11 @@
       }
     },
     "node_modules/marked": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.2.tgz",
-      "integrity": "sha512-85RUkoYKIVB21PbMKrnD6aCl9ws+XKEyhJNMbLn206NyD3jbBo7Ec7Wi4Jrsn4dV1a2ng7K/jfkmIN0DNoS41w==",
+      "version": "15.0.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.3.tgz",
+      "integrity": "sha512-Ai0cepvl2NHnTcO9jYDtcOEtVBNVYR31XnEA3BndO7f5As1wzpcOceSUM8FDkNLJNIODcLpDTWay/qQhqbuMvg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -21728,9 +21729,9 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.2.tgz",
-      "integrity": "sha512-ZF5gQIQa/UmzfvxbHZI3JXN0/Jt+vnAfAviNRAMc491laiK6YCLpCW9ft8oaCRFOTxCZtUTE6XB0ZQAe3olntw==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
+      "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
- Dependabot: Bump electron-to-chromium from 1.5.66 to 1.5.67
- Dependabot: Bump marked from 15.0.2 to 15.0.3
- Dependabot: Bump ts-api-utils from 1.4.2 to 1.4.3
- Dependabot: Bump psl from 1.13.0 to 1.14.0
