### PR TITLE
combine all dependabot prs 2024 12 05 1138

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -233,13 +233,14 @@
       }
     },
     "node_modules/@babel/helper-create-regexp-features-plugin": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.25.9.tgz",
-      "integrity": "sha512-ORPNZ3h6ZRkOyAa/SaHU+XsLZr0UQzRwuDQ0cczIA17nAzZ+85G5cVkOJIj7QavLZGSe8QXUmNFxSZzjcZF9bw==",
+      "version": "7.26.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.26.3.tgz",
+      "integrity": "sha512-G7ZRb40uUgdKOQqPLjfD12ZmGA54PzqDFUv2BKImnC9QIfGhIHKvVML0oN8IUiDq4iRqpq74ABpvOaerfWdong==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.25.9",
-        "regexpu-core": "^6.1.1",
+        "regexpu-core": "^6.2.0",
         "semver": "^6.3.1"
       },
       "engines": {


### PR DESCRIPTION
- Dependabot: Bump preact from 10.25.0 to 10.25.1
- Dependabot: Bump is-boolean-object from 1.1.2 to 1.2.0
- Dependabot: Bump rollup from 4.27.4 to 4.28.0
- Dependabot: Bump has-proto from 1.0.3 to 1.1.0
- Dependabot: Bump is-string from 1.0.7 to 1.1.0
- Dependabot: Bump psl from 1.14.0 to 1.15.0
- Dependabot: Bump nwsapi from 2.2.13 to 2.2.16
- Dependabot: Bump @storybook/csf from 0.1.11 to 0.1.12
- Dependabot: Bump is-number-object from 1.0.7 to 1.1.0
- Dependabot: Bump has-symbols from 1.0.3 to 1.1.0
- Dependabot: Bump resolve.exports from 2.0.2 to 2.0.3
- Dependabot: Bump is-bigint from 1.0.4 to 1.1.0
- Dependabot: Bump which-boxed-primitive from 1.0.2 to 1.1.0
- Dependabot: Bump is-symbol from 1.0.4 to 1.1.0
- Dependabot: Bump caniuse-lite from 1.0.30001684 to 1.0.30001686
- Dependabot: Bump @typescript-eslint/utils from 8.16.0 to 8.17.0
- Dependabot: Bump dotenv from 16.4.5 to 16.4.7
- Dependabot: Bump @types/react from 18.3.12 to 18.3.13
- Dependabot: Bump electron-to-chromium from 1.5.67 to 1.5.70
- Dependabot: Bump @babel/generator from 7.26.2 to 7.26.3
- Dependabot: Bump @babel/preset-react from 7.25.9 to 7.26.3
- Dependabot: Bump gopd from 1.0.1 to 1.2.0
- Dependabot: Bump @babel/types from 7.26.0 to 7.26.3
- Dependabot: Bump @babel/plugin-transform-exponentiation-operator
- Dependabot: Bump @babel/parser from 7.26.2 to 7.26.3
- Dependabot: Bump @babel/compat-data from 7.26.2 to 7.26.3
- Dependabot: Bump @babel/plugin-transform-modules-commonjs
- Dependabot: Bump @babel/plugin-transform-typescript
- Dependabot: Bump @babel/traverse from 7.25.9 to 7.26.3
- Dependabot: Bump @babel/helper-create-regexp-features-plugin
