### PR TITLE
combine all dependabot prs 2024 12 07 5493

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2030,9 +2030,9 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.26.3",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.3.tgz",
-      "integrity": "sha512-yTmc8J+Sj8yLzwr4PD5Xb/WF3bOYu2C2OoSZPzbuqRm4n98XirsbzaX+GloeO376UnSYIYJ4NCanwV5/ugZkwA==",
+      "version": "7.26.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.4.tgz",
+      "integrity": "sha512-fH+b7Y4p3yqvApJALCPJcwb0/XaOSgtK4pzV6WVjPR5GLFQBRI7pfoX2V2iM48NXvX07NUxxm1Vw98YjqTcU5w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
- Dependabot: Bump caniuse-lite from 1.0.30001686 to 1.0.30001687
- Dependabot: Bump flow-parser from 0.255.0 to 0.256.0
- Dependabot: Bump @types/prop-types from 15.7.13 to 15.7.14
- Dependabot: Bump electron-to-chromium from 1.5.70 to 1.5.71
- Dependabot: Bump @storybook/icons from 1.2.12 to 1.3.0
- Dependabot: Bump express from 4.21.1 to 4.21.2
- Dependabot: Bump @types/react from 18.3.13 to 18.3.14
- Dependabot: Bump call-bind from 1.0.7 to 1.0.8
- Dependabot: Bump @babel/traverse from 7.26.3 to 7.26.4
