### PR TITLE
combine all dependabot prs 2025 01 10 7813

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22259,9 +22259,9 @@
       }
     },
     "node_modules/unplugin": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-1.16.0.tgz",
-      "integrity": "sha512-5liCNPuJW8dqh3+DM6uNM2EI3MLLpCKp/KY+9pB5M2S2SR2qvvDHhKgBOaTWEbZTAws3CXfB0rKTIolWKL05VQ==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-1.16.1.tgz",
+      "integrity": "sha512-4/u/j4FrCKdi17jaxuJA0jClGxB1AvU2hw/IuayPc4ay1XGaJs/rbb4v5WKwAjNifjmXK9PIFyuPiaK8azyR9w==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.14.0",


### PR DESCRIPTION
- Dependabot: Bump flow-parser from 0.258.0 to 0.258.1
- Dependabot: Bump electron-to-chromium from 1.5.78 to 1.5.79
- Dependabot: Bump core-js-compat from 3.39.0 to 3.40.0
- Dependabot: Bump update-browserslist-db from 1.1.1 to 1.1.2
- Dependabot: Bump core-js from 3.39.0 to 3.40.0
- Dependabot: Bump browserslist from 4.24.3 to 4.24.4
- Dependabot: Bump unplugin from 1.16.0 to 1.16.1
