### PR TITLE
combine all dependabot prs 2025 01 26 3969

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9296,10 +9296,11 @@
       }
     },
     "node_modules/@ungap/structured-clone": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.1.tgz",
-      "integrity": "sha512-fEzPV3hSkSMltkw152tJKNARhOupqbH96MZWyRjNaYZOMIzbrTeQDG+MTc6Mr2pgzFQzFxAfmhGDNP5QK++2ZA==",
-      "dev": true
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@vitest/expect": {
       "version": "1.6.0",


### PR DESCRIPTION
- Dependabot: Bump vite-prerender-plugin from 0.5.3 to 0.5.4
- Dependabot: Bump magic-string from 0.30.8 to 0.30.17
- Dependabot: Bump @types/node from 18.19.71 to 18.19.74
- Dependabot: Bump is-async-function from 2.1.0 to 2.1.1
- Dependabot: Bump electron-to-chromium from 1.5.84 to 1.5.87
- Dependabot: Bump rollup from 4.31.0 to 4.32.0
- Dependabot: Bump decimal.js from 10.4.3 to 10.5.0
- Dependabot: Bump @types/emscripten from 1.39.13 to 1.40.0
- Dependabot: Bump @storybook/icons from 1.3.0 to 1.3.2
- Dependabot: Bump @ungap/structured-clone from 1.2.1 to 1.3.0
