### PR TITLE
combine all dependabot prs 2025 01 28 3598

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -406,13 +406,14 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.0.tgz",
-      "integrity": "sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==",
+      "version": "7.26.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.7.tgz",
+      "integrity": "sha512-8NHiL98vsi0mbPQmYAGWwfcFaOy4j2HY49fXJCfuDcdE7fMIsH9a7GdaeXpIBsbT7307WU8KCMp5pUVDNL4f9A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.25.9",
-        "@babel/types": "^7.26.0"
+        "@babel/types": "^7.26.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2044,10 +2045,11 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.5.tgz",
-      "integrity": "sha512-L6mZmwFDK6Cjh1nRCLXpa6no13ZIioJDz7mdkzHv399pThrTa/k0nUlNaenOeh2kWu/iaOQYElEpKPUswUa9Vg==",
+      "version": "7.26.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.7.tgz",
+      "integrity": "sha512-t8kDRGrKXyp6+tjUh7hw2RLyclsW4TRoRvRHtSyAX9Bb5ldlFh+90YAYY6awRXrlB4G5G2izNeGySpATlFzmOg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.25.9",
         "@babel/helper-validator-identifier": "^7.25.9"


### PR DESCRIPTION
- Dependabot: Bump @babel/plugin-transform-typescript
- Dependabot: Bump @babel/core from 7.26.0 to 7.26.7
- Dependabot: Bump @babel/preset-env from 7.26.0 to 7.26.7
- Dependabot: Bump @babel/plugin-transform-typeof-symbol
- Dependabot: Bump @babel/parser from 7.26.5 to 7.26.7
- Dependabot: Bump @babel/traverse from 7.26.5 to 7.26.7
- Dependabot: Bump @babel/runtime from 7.26.0 to 7.26.7
- Dependabot: Bump for-each from 0.3.3 to 0.3.4
- Dependabot: Bump @babel/types from 7.26.5 to 7.26.7
- Dependabot: Bump @babel/helpers from 7.26.0 to 7.26.7
