### PR TITLE
combine all dependabot prs 2025 02 08 2834

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10487,9 +10487,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001695",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001695.tgz",
-      "integrity": "sha512-vHyLade6wTgI2u1ec3WQBxv+2BrTERV28UXQu9LO6lZ9pYeMk34vjXFLOxo1A4UBA8XTL4njRQZdno/yYaSmWw==",
+      "version": "1.0.30001698",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001698.tgz",
+      "integrity": "sha512-xJ3km2oiG/MbNU8G6zIq6XRZ6HtAOVXsbOrP/blGazi52kc5Yy7b6sDA5O+FbROzRrV7BSTllLHuNvmawYUJjw==",
       "dev": true,
       "funding": [
         {
@@ -10504,7 +10504,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chai": {
       "version": "4.5.0",


### PR DESCRIPTION
- Dependabot: Bump giget from 1.2.3 to 1.2.4
- Dependabot: Bump @types/lodash from 4.17.14 to 4.17.15
- Dependabot: Bump @prefresh/vite from 2.4.6 to 2.4.7
- Dependabot: Bump cjs-module-lexer from 1.4.1 to 1.4.3
- Dependabot: Bump tocbot from 4.32.2 to 4.33.0
- Dependabot: Bump fastq from 1.18.0 to 1.19.0
- Dependabot: Bump ts-api-utils from 2.0.0 to 2.0.1
- Dependabot: Bump @preact/preset-vite from 2.10.0 to 2.10.1
- Dependabot: Bump import-fresh from 3.3.0 to 3.3.1
- Dependabot: Bump @types/node from 18.19.74 to 18.19.75
- Dependabot: Bump @typescript-eslint/utils from 8.21.0 to 8.23.0
- Dependabot: Bump is-weakref from 1.1.0 to 1.1.1
- Dependabot: Bump object-inspect from 1.13.3 to 1.13.4
- Dependabot: Bump is-boolean-object from 1.2.1 to 1.2.2
- Dependabot: Bump vite-prerender-plugin from 0.5.5 to 0.5.6
- Dependabot: Bump possible-typed-array-names from 1.0.0 to 1.1.0
- Dependabot: Bump electron-to-chromium from 1.5.88 to 1.5.96
- Dependabot: Bump rollup from 4.32.0 to 4.34.5
- Dependabot: Bump caniuse-lite from 1.0.30001695 to 1.0.30001698
