### PR TITLE
combine all dependabot prs 2025 02 15 9675

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2052,9 +2052,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.7.tgz",
-      "integrity": "sha512-t8kDRGrKXyp6+tjUh7hw2RLyclsW4TRoRvRHtSyAX9Bb5ldlFh+90YAYY6awRXrlB4G5G2izNeGySpATlFzmOg==",
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.9.tgz",
+      "integrity": "sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
- Dependabot: Bump marked from 15.0.6 to 15.0.7
- Dependabot: Bump @babel/compat-data from 7.26.5 to 7.26.8
- Dependabot: Bump @babel/eslint-parser from 7.26.5 to 7.26.8
- Dependabot: Bump @babel/plugin-transform-typescript
- Dependabot: Bump caniuse-lite from 1.0.30001698 to 1.0.30001699
- Dependabot: Bump @babel/plugin-transform-template-literals
- Dependabot: Bump @typescript-eslint/utils from 8.23.0 to 8.24.0
- Dependabot: Bump postcss from 8.5.1 to 8.5.2
- Dependabot: Bump compression from 1.7.5 to 1.8.0
- Dependabot: Bump for-each from 0.3.4 to 0.3.5
- Dependabot: Bump es-shim-unscopables from 1.0.2 to 1.1.0
- Dependabot: Bump pathe from 2.0.2 to 2.0.3
- Dependabot: Bump tocbot from 4.33.0 to 4.35.0
- Dependabot: Bump @adobe/css-tools from 4.4.1 to 4.4.2
- Dependabot: Bump call-bind-apply-helpers from 1.0.1 to 1.0.2
- Dependabot: Bump @babel/template from 7.25.9 to 7.26.9
- Dependabot: Bump @babel/parser from 7.26.7 to 7.26.9
- Dependabot: Bump @babel/helpers from 7.26.7 to 7.26.9
- Dependabot: Bump @babel/helper-create-class-features-plugin
- Dependabot: Bump @types/node from 18.19.75 to 18.19.76
- Dependabot: Bump flow-parser from 0.259.1 to 0.261.1
- Dependabot: Bump @babel/runtime from 7.26.7 to 7.26.9
- Dependabot: Bump rollup from 4.34.5 to 4.34.7
- Dependabot: Bump @babel/traverse from 7.26.7 to 7.26.9
- Dependabot: Bump @babel/core from 7.26.7 to 7.26.9
- Dependabot: Bump @babel/plugin-transform-for-of from 7.25.9 to 7.26.9
- Dependabot: Bump @babel/generator from 7.26.5 to 7.26.9
- Dependabot: Bump electron-to-chromium from 1.5.96 to 1.5.100
- Dependabot: Bump @babel/preset-env from 7.26.7 to 7.26.9
- Dependabot: Bump @babel/types from 7.26.7 to 7.26.9
