### PR TITLE
0.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@al-mabsut/muslimah",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@al-mabsut/muslimah",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "ISC",
       "devDependencies": {
         "@babel/core": "^7.23.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al-mabsut/muslimah",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Shari' ahkaam related to muslim women matters",
   "main": "dist/cjs/bundle.js",
   "module": "dist/esm/bundle.js",


### PR DESCRIPTION
Update version to check if affects legacy app.
As after building the library locally it seems to be working fine, but when using the current version it appears with no style, icons at all : 

<img width="403" alt="image" src="https://github.com/user-attachments/assets/0ed82957-7fe9-4cbc-84f8-0ad5f1831d7a" />

Even tried in another project : 

<img width="856" alt="image" src="https://github.com/user-attachments/assets/4e03ec8a-96aa-41bb-930f-dbb8d9d71581" />
